### PR TITLE
fix: revert to node16, build to mjs, and use more modern ulid package

### DIFF
--- a/apps/test-app-runtime/package.json
+++ b/apps/test-app-runtime/package.json
@@ -13,8 +13,7 @@
     "@aws-sdk/client-lambda": "^3.204.0",
     "@aws-sdk/lib-dynamodb": "^3.204.0",
     "@eventual/aws-runtime": "workspace:^",
-    "@eventual/core": "workspace:^",
-    "ulid": "^2.3.0"
+    "@eventual/core": "workspace:^"
   },
   "devDependencies": {
     "@eventual/compiler": "workspace:^",

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -11,8 +11,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.50.0",
-    "constructs": "^10.1.154",
-    "ulid": "^2.3.0"
+    "constructs": "^10.1.154"
   },
   "devDependencies": {
     "@eventual/aws-cdk": "workspace:^",

--- a/packages/@eventual/aws-cdk/package.json
+++ b/packages/@eventual/aws-cdk/package.json
@@ -9,8 +9,7 @@
   "dependencies": {
     "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "2.50.0-alpha.0",
     "@eventual/aws-runtime": "workspace:^",
-    "@eventual/compiler": "workspace:^",
-    "ulid": "^2.3.0"
+    "@eventual/compiler": "workspace:^"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.50.0",

--- a/packages/@eventual/aws-cdk/src/workflow.ts
+++ b/packages/@eventual/aws-cdk/src/workflow.ts
@@ -4,6 +4,7 @@ import {
   Function,
   Code,
   IFunction,
+  Runtime,
 } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import { Bucket, IBucket } from "aws-cdk-lib/aws-s3";
@@ -25,7 +26,6 @@ import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import path from "path";
 import { execSync } from "child_process";
 import { IGrantable, IPrincipal } from "aws-cdk-lib/aws-iam";
-import { NODE_18_X } from "./utils";
 
 export interface WorkflowProps {
   entry: string;
@@ -109,7 +109,7 @@ export class Workflow extends Construct implements IGrantable {
           "../../esm/functions/start-workflow.js"
         ),
         handler: "handle",
-        runtime: NODE_18_X,
+        runtime: Runtime.NODEJS_16_X,
         architecture: Architecture.ARM_64,
         bundling: {
           // https://github.com/aws/aws-cdk/issues/21329#issuecomment-1212336356
@@ -151,7 +151,7 @@ export class Workflow extends Construct implements IGrantable {
       code: Code.fromAsset(path.join(outDir, "activity-worker")),
       // the bundler outputs activity-worker/index.js
       handler: "index.default",
-      runtime: NODE_18_X,
+      runtime: Runtime.NODEJS_16_X,
       memorySize: 512,
       environment: {
         NODE_OPTIONS: "--enable-source-maps",
@@ -173,7 +173,7 @@ export class Workflow extends Construct implements IGrantable {
       code: Code.fromAsset(path.join(outDir, "orchestrator")),
       // the bundler outputs orchestrator/index.js
       handler: "index.default",
-      runtime: NODE_18_X,
+      runtime: Runtime.NODEJS_16_X,
       memorySize: 512,
       environment: {
         NODE_OPTIONS: "--enable-source-maps",

--- a/packages/@eventual/aws-runtime/package.json
+++ b/packages/@eventual/aws-runtime/package.json
@@ -17,7 +17,7 @@
     "aws-lambda": "^1.0.7",
     "fast-equals": "^4.0.3",
     "micro-memoize": "^4.0.11",
-    "ulid": "^2.3.0",
+    "ulidx": "^0.3.0",
     "aws-embedded-metrics": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/@eventual/aws-runtime/src/clients/execution-history-client.ts
+++ b/packages/@eventual/aws-runtime/src/clients/execution-history-client.ts
@@ -11,7 +11,7 @@ import {
   isHistoryEvent,
   WorkflowEvent,
 } from "@eventual/core";
-import { ulid } from "ulid";
+import { ulid } from "ulidx";
 
 export interface ExecutionHistoryClientProps {
   readonly dynamo: DynamoDBClient;

--- a/packages/@eventual/aws-runtime/src/clients/workflow-client.ts
+++ b/packages/@eventual/aws-runtime/src/clients/workflow-client.ts
@@ -12,7 +12,7 @@ import {
   WorkflowEventType,
   HistoryStateEvents,
 } from "@eventual/core";
-import { ulid } from "ulid";
+import { ulid } from "ulidx";
 import { ExecutionHistoryClient } from "./execution-history-client.js";
 
 export interface WorkflowClientProps {

--- a/packages/@eventual/compiler/src/eventual-bundle.ts
+++ b/packages/@eventual/compiler/src/eventual-bundle.ts
@@ -33,9 +33,9 @@ async function main() {
         conditions: ["module", "import", "require"],
         // supported with NODE_18.x runtime
         // TODO: make this configurable.
-        external: ["@aws-sdk"],
+        // external: ["@aws-sdk"],
         platform: "node",
-        format: "cjs",
+        format: "esm",
         metafile: true,
         bundle: true,
         entryPoints: [
@@ -44,7 +44,9 @@ async function main() {
             "../../esm/entry/orchestrator.js"
           ),
         ],
-        outfile: path.join(outDir, "orchestrator/index.js"),
+        // // ulid
+        banner: esmPolyfillRequireBanner(),
+        outfile: path.join(outDir, "orchestrator/index.mjs"),
       })
       .then(writeEsBuildMetafile(path.join(outDir, "orchestrator/meta.json"))),
     esbuild
@@ -59,9 +61,9 @@ async function main() {
         conditions: ["module", "import", "require"],
         // supported with NODE_18.x runtime
         // TODO: make this configurable.
-        external: ["@aws-sdk"],
+        // external: ["@aws-sdk"],
         platform: "node",
-        format: "cjs",
+        format: "esm",
         metafile: true,
         bundle: true,
         entryPoints: [
@@ -70,12 +72,25 @@ async function main() {
             "../../esm/entry/activity-worker.js"
           ),
         ],
-        outfile: path.join(outDir, "activity-worker/index.js"),
+        banner: esmPolyfillRequireBanner(),
+        outfile: path.join(outDir, "activity-worker/index.mjs"),
       })
       .then(
         writeEsBuildMetafile(path.join(outDir, "activity-worker/meta.json"))
       ),
   ]);
+}
+
+/**
+ * Allows ESM module bundles to support dynamo requires when necessary.
+ */
+function esmPolyfillRequireBanner() {
+  return {
+    js: [
+      `import { createRequire as topLevelCreateRequire } from 'module'`,
+      `const require = topLevelCreateRequire(import.meta.url)`,
+    ].join("\n"),
+  };
 }
 
 function writeEsBuildMetafile(path: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,11 +37,9 @@ importers:
       ts-jest: ^29
       ts-node: ^10.9.1
       typescript: ^4.8.4
-      ulid: ^2.3.0
     dependencies:
       aws-cdk-lib: 2.50.0_constructs@10.1.154
       constructs: 10.1.154
-      ulid: 2.3.0
     devDependencies:
       '@eventual/aws-cdk': link:../../packages/@eventual/aws-cdk
       '@eventual/cli': link:../../packages/@eventual/cli
@@ -72,7 +70,6 @@ importers:
       ts-jest: ^29
       ts-node: ^10.9.1
       typescript: ^4.8.4
-      ulid: ^2.3.0
     dependencies:
       '@aws-sdk/client-dynamodb': 3.204.0
       '@aws-sdk/client-lambda': 3.204.0
@@ -81,7 +78,6 @@ importers:
       '@aws-sdk/lib-dynamodb': 3.210.0_2yfvsogv6cyvotniby7kbgsjhe
       '@eventual/aws-runtime': link:../../packages/@eventual/aws-runtime
       '@eventual/core': link:../../packages/@eventual/core
-      ulid: 2.3.0
     devDependencies:
       '@eventual/compiler': link:../../packages/@eventual/compiler
       '@types/aws-lambda': 8.10.108
@@ -111,12 +107,10 @@ importers:
       ts-jest: ^29
       ts-node: ^10.9.1
       typescript: ^4.8.4
-      ulid: ^2.3.0
     dependencies:
       '@aws-cdk/aws-apigatewayv2-authorizers-alpha': 2.50.0-alpha.0_ntleitg5fbqtbxprhns64fsb3a
       '@eventual/aws-runtime': link:../aws-runtime
       '@eventual/compiler': link:../compiler
-      ulid: 2.3.0
     devDependencies:
       '@aws-cdk/aws-apigatewayv2-alpha': 2.50.0-alpha.0_wfetmkylzcavk2jugrcqqsc5se
       '@aws-cdk/aws-apigatewayv2-integrations-alpha': 2.50.0-alpha.0_ntleitg5fbqtbxprhns64fsb3a
@@ -151,14 +145,14 @@ importers:
       ts-jest: ^29
       ts-node: ^10.9.1
       typescript: ^4.8.4
-      ulid: ^2.3.0
+      ulidx: ^0.3.0
     dependencies:
       '@eventual/core': link:../core
       aws-embedded-metrics: 4.0.0
       aws-lambda: 1.0.7
       fast-equals: 4.0.3
       micro-memoize: 4.0.11
-      ulid: 2.3.0
+      ulidx: 0.3.0
     devDependencies:
       '@aws-sdk/client-dynamodb': 3.208.0
       '@aws-sdk/client-lambda': 3.208.0
@@ -7249,7 +7243,7 @@ packages:
       pretty-format: 29.3.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_fvpuwgkpfe3dm3hnpcpbcxmb3y
+      ts-node: 10.9.1_e7yvbkxpwwqnzxz2s2bfjt7zx4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7289,7 +7283,7 @@ packages:
       pretty-format: 29.3.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_fvpuwgkpfe3dm3hnpcpbcxmb3y
+      ts-node: 10.9.1_e7yvbkxpwwqnzxz2s2bfjt7zx4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7727,6 +7721,10 @@ packages:
   /ky/0.32.2:
     resolution: {integrity: sha512-eBJeF6IXNwX5rksdwBrE2rIJrU2d84GoTvdM7OmmTIwUVXEMd72wIwvT+nyhrqtv7AzbSNsWz7yRsHgVhj1uog==}
     engines: {node: '>=14.16'}
+
+  /layerr/0.1.2:
+    resolution: {integrity: sha512-ob5kTd9H3S4GOG2nVXyQhOu9O8nBgP555XxWPkJI0tR0JeRilfyTp8WtPdIJHLXBmHMSdEq5+KMxiYABeScsIQ==}
+    dev: false
 
   /lerna/5.6.2:
     resolution: {integrity: sha512-Y0yMPslvnBnTZi7Nrs/gDyYZYauNf61xWNCehISHIORxZmmpoluNkcWTfcyb47is5uJQCv5QJX5xKKubbs+a6w==}
@@ -9900,8 +9898,10 @@ packages:
     dev: true
     optional: true
 
-  /ulid/2.3.0:
-    resolution: {integrity: sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==}
+  /ulidx/0.3.0:
+    resolution: {integrity: sha512-Qvpa2xAzS6fBUpiqHSHWvn6XiSLCAPyNDDz035vsEWmUoXRqC4c9JySLIfdBuK0N1xGBxng6GHDOZgyNQfxAHg==}
+    dependencies:
+      layerr: 0.1.2
     dev: false
 
   /unique-filename/2.0.1:


### PR DESCRIPTION
* Lambda node18 and @aws-sdk seem to have worse cold start times.
    * Did some [experimenting](https://twitter.com/sussmansa/status/1593804631192346624) with node18 and lambda bundled @aws-sdk. 
* Replaced `ulid` with `ulidx` as `ulid` has not been updated in 5 years and contains dynamic requires.
* Bundle into .mjs with end to end ESM. We'll now get top level await and other benefits.