### PR TITLE
chore: refactor core/runtime into core/runtime/clients

### DIFF
--- a/packages/@eventual/core/src/global.ts
+++ b/packages/@eventual/core/src/global.ts
@@ -1,5 +1,5 @@
 import type { Eventual, EventualCallCollector } from "./eventual.js";
-import type { WorkflowClient } from "./runtime/workflow-client.js";
+import type { WorkflowClient } from "./runtime/clients/workflow-client.js";
 import type { Workflow } from "./workflow.js";
 
 export const workflows = (): Map<string, Workflow> =>

--- a/packages/@eventual/core/src/runtime/clients/activity-runtime-client.ts
+++ b/packages/@eventual/core/src/runtime/clients/activity-runtime-client.ts
@@ -1,4 +1,4 @@
-import { ScheduleActivityCommand } from "../command.js";
+import { ScheduleActivityCommand } from "../../command.js";
 
 export interface ActivityRuntimeClient {
   /**

--- a/packages/@eventual/core/src/runtime/clients/execution-history-client.ts
+++ b/packages/@eventual/core/src/runtime/clients/execution-history-client.ts
@@ -1,4 +1,4 @@
-import { WorkflowEvent } from "../events.js";
+import { WorkflowEvent } from "../../events.js";
 
 export type UnresolvedEvent<T extends WorkflowEvent> = Omit<
   T,

--- a/packages/@eventual/core/src/runtime/clients/index.ts
+++ b/packages/@eventual/core/src/runtime/clients/index.ts
@@ -1,0 +1,5 @@
+export * from "./activity-runtime-client.js";
+export * from "./execution-history-client.js";
+export * from "./timer-client.js";
+export * from "./workflow-client.js";
+export * from "./workflow-runtime-client.js";

--- a/packages/@eventual/core/src/runtime/clients/timer-client.ts
+++ b/packages/@eventual/core/src/runtime/clients/timer-client.ts
@@ -1,4 +1,4 @@
-import { HistoryStateEvent } from "../events.js";
+import { HistoryStateEvent } from "../../events.js";
 
 export interface TimerClient {
   /**

--- a/packages/@eventual/core/src/runtime/clients/workflow-client.ts
+++ b/packages/@eventual/core/src/runtime/clients/workflow-client.ts
@@ -1,7 +1,7 @@
-import { HistoryStateEvent } from "../events.js";
-import { Execution, ExecutionStatus } from "../execution.js";
-import { Signal } from "../signals.js";
-import { Workflow, WorkflowInput } from "../workflow.js";
+import { HistoryStateEvent } from "../../events.js";
+import { Execution, ExecutionStatus } from "../../execution.js";
+import { Signal } from "../../signals.js";
+import { Workflow, WorkflowInput } from "../../workflow.js";
 
 export interface WorkflowClient {
   /**

--- a/packages/@eventual/core/src/runtime/clients/workflow-runtime-client.ts
+++ b/packages/@eventual/core/src/runtime/clients/workflow-runtime-client.ts
@@ -3,14 +3,14 @@ import {
   SleepForCommand,
   SleepUntilCommand,
   ExpectSignalCommand,
-} from "../command.js";
+} from "../../command.js";
 import {
   ActivityScheduled,
   HistoryStateEvent,
   SleepScheduled,
   ExpectSignalStarted,
-} from "../events.js";
-import { CompleteExecution, FailedExecution } from "../execution.js";
+} from "../../events.js";
+import { CompleteExecution, FailedExecution } from "../../execution.js";
 
 export interface CompleteExecutionRequest {
   executionId: string;

--- a/packages/@eventual/core/src/runtime/index.ts
+++ b/packages/@eventual/core/src/runtime/index.ts
@@ -1,6 +1,2 @@
-export * from "./activity-runtime-client.js";
-export * from "./execution-history-client.js";
-export * from "./timer-client.js";
-export * from "./workflow-client.js";
-export * from "./workflow-runtime-client.js";
+export * from "./clients/index.js";
 export * from "./flags.js";

--- a/packages/@eventual/core/src/workflow.ts
+++ b/packages/@eventual/core/src/workflow.ts
@@ -18,7 +18,7 @@ import {
   WorkflowEventType,
 } from "./events.js";
 import { interpret, WorkflowResult } from "./interpret.js";
-import type { StartWorkflowResponse } from "./runtime/workflow-client.js";
+import type { StartWorkflowResponse } from "./runtime/clients/workflow-client.js";
 import { ChildExecution, createWorkflowCall } from "./calls/workflow-call.js";
 import { AwaitedEventual } from "./eventual.js";
 import { isOrchestratorWorker } from "./runtime/flags.js";


### PR DESCRIPTION
Slowly starting to prepare @eventual/core for containing the general implementation of the runtime