### PR TITLE
Fix tsconfig for sst template, use projectName as default service name

### DIFF
--- a/packages/create-eventual/src/aws-cdk.ts
+++ b/packages/create-eventual/src/aws-cdk.ts
@@ -140,10 +140,10 @@ packages:
         .mkdir("src")
         .then(() =>
           Promise.all([
-            fs.writeFile(path.join("src", "app.ts"), sampleCDKApp),
+            fs.writeFile(path.join("src", "app.ts"), sampleCDKApp(projectName)),
             fs.writeFile(
-              path.join("src", "my-service-stack.ts"),
-              sampleCDKStack
+              path.join("src", `${projectName}-stack.ts`),
+              sampleCDKStack(projectName)
             ),
           ])
         ),

--- a/packages/create-eventual/src/aws-sst.ts
+++ b/packages/create-eventual/src/aws-sst.ts
@@ -1,5 +1,5 @@
 import type { PackageManager } from "./index";
-import { addDeps, addDevDeps, addTsLib, exec } from "./util";
+import { addDeps, addDevDeps, addTsLib, exec, modifyTsConfig, overrideTsCompilerOptions } from "./util";
 import path from "path";
 import fs from "fs/promises";
 import { sampleSSTCode, sampleServiceCode } from "./sample-code";
@@ -19,18 +19,35 @@ export async function createAwsSst({
   );
 
   process.chdir(path.join(".", projectName));
+
+  await modifyTsConfig(path.join(".", "tsconfig.json"), [
+    (tsConfig) => overrideTsCompilerOptions(tsConfig, {
+      module: "esnext",
+      target: "ES2021",
+    }),
+  ])
+
+
   await Promise.all([
     addDevDeps(pkgManager, "@eventual/aws-cdk", "@eventual/cli"),
-    fs.writeFile(path.join(".", "stacks", "MyStack.ts"), sampleSSTCode),
+    fs.writeFile(path.join(".", "stacks", "MyStack.ts"), sampleSSTCode(projectName)),
   ]);
 
   process.chdir("services");
   await addDeps(pkgManager, "@eventual/core");
+  await modifyTsConfig(path.join(".", "tsconfig.json"), [
+    (tsConfig) => addTsLib(tsConfig, "DOM"),
+    (tsConfig) => overrideTsCompilerOptions(tsConfig, {
+      module: "esnext",
+      target: "ES2021",
+    }),
+  ])
 
   await Promise.all([
     // Our API relies on the DOM types for node
-    addTsLib(path.join(".", "tsconfig.json"), "DOM"),
     fs.rm(path.join(".", "functions", "lambda.ts")),
     fs.writeFile(path.join(".", "functions", "service.ts"), sampleServiceCode),
   ]);
+
+
 }

--- a/packages/create-eventual/src/sample-code.ts
+++ b/packages/create-eventual/src/sample-code.ts
@@ -35,7 +35,8 @@ export interface WorkDoneEvent {
 export const workDone = event<WorkDoneEvent>("WorkDone");
 `;
 
-export const sampleSSTCode = `import { StackContext } from "@serverless-stack/resources";
+export function sampleSSTCode(projectName: string) {
+  return `import { StackContext } from "@serverless-stack/resources";
 import { Service } from "@eventual/aws-cdk";
 import path from "path";
 import url from "url";
@@ -46,23 +47,27 @@ export function MyStack({ stack }: StackContext) {
   const service = new Service(stack, "Service", {
     // this path is relative to .build/ where SST puts the CDK bundle
     entry: path.resolve(__dirname, "..", "..", "services", "functions", "service.ts"),
-    name: "my-service",
+    name: "${projectName}",
   });
   stack.addOutputs({
     ApiEndpoint: service.api.gateway.url!,
   });
 }
 `;
+}
 
-export const sampleCDKApp = `import { App } from "aws-cdk-lib";
-import { MyServiceStack } from "./my-service-stack";
+export function sampleCDKApp(projectName: string) {
+  return `import { App } from "aws-cdk-lib";
+import { MyServiceStack } from "./${projectName}-stack";
 
 const app = new App();
 
-new MyServiceStack(app, "my-service");
+new MyServiceStack(app, "${projectName}");
 `;
+}
 
-export const sampleCDKStack = `import { Construct } from "constructs";
+export function sampleCDKStack(projectName: string) {
+  return `import { Construct } from "constructs";
 import { Stack, StackProps } from "aws-cdk-lib";
 import { Service } from "@eventual/aws-cdk";
 import path from "path";
@@ -75,10 +80,11 @@ export class MyServiceStack extends Stack {
   constructor(scope: Construct, id: string, props?: MyServiceStackProps) {
     super(scope, id, props);
 
-    this.service = new Service(this, "my-service", {
-      name: "my-service",
+    this.service = new Service(this, "${projectName}", {
+      name: "${projectName}",
       entry: path.join(__dirname, "..", "..", "services", "src", "index.ts")
     });
   }
 }
 `;
+}

--- a/packages/create-eventual/src/util.ts
+++ b/packages/create-eventual/src/util.ts
@@ -51,18 +51,30 @@ export async function install(pkgManager: PackageManager) {
   }
 }
 
-export async function addTsLib(file: string, ...libs: string[]) {
-  const tsConfig = JSON.parse((await fs.readFile(file)).toString("utf-8"));
+export async function modifyTsConfig(file: string, transformations: Array<(tsConfig: any) => void>) {
+  let tsConfig = JSON.parse((await fs.readFile(file)).toString("utf-8"));
   tsConfig.compilerOptions ??= {};
-  const lib: string[] = (tsConfig.compilerOptions.lib ??= []);
-  for (const newLib of libs) {
-    if (
-      lib.find(
-        (existingLib) => existingLib.toLowerCase() === newLib.toLowerCase()
-      ) !== undefined
-    ) {
-      lib.push(newLib);
-    }
+  tsConfig.compilerOptions.lib ??= [];
+  for (let t of transformations) {
+    t(tsConfig);
   }
   await fs.writeFile(file, JSON.stringify(tsConfig, null, 2));
 }
+
+export async function addTsLib(tsConfig: any, ...libs: string[]) {
+    const lib = tsConfig.compilerOptions.lib;
+    for (const newLib of libs) {
+      if (
+        lib.find(
+          (existingLib: string) => existingLib.toLowerCase() === newLib.toLowerCase()
+        ) === undefined
+      ) {
+        lib.push(newLib);
+      }
+  };
+}
+
+export async function overrideTsCompilerOptions(tsConfig: any, options: Record<string, string>) {
+  tsConfig.compilerOptions = { ...tsConfig.compilerOptions, ...options };
+}
+


### PR DESCRIPTION
Fixes and enhances cdk and sst templates.

* Ensures tsconfig files are configured to allow use of import.meta properties as the template uses this.
* SST template generation was not correctly adding the "DOM" library.
* Enables generated code to inject the project name instead of "my-service"
 