### PR TITLE
chore: enable importModuleSpecifier relative

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,5 +40,6 @@
   "editor.insertSpaces": true,
   "editor.formatOnSave": true,
   "eslint.format.enable": false,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.preferences.importModuleSpecifier": "relative"
 }


### PR DESCRIPTION
This will prevent this bug from happening when using vs code to auto import: https://github.com/functionless/eventual/pull/222