### PR TITLE
fix: give physical names to Lambdas and the Execution LogGroup and simplify getting started

### DIFF
--- a/packages/@eventual/aws-cdk/src/activities.ts
+++ b/packages/@eventual/aws-cdk/src/activities.ts
@@ -18,6 +18,7 @@ import { Events } from "./events";
 import { Logging } from "./logging";
 
 export interface ActivitiesProps {
+  serviceName: string;
   workflows: IWorkflows;
   scheduler: IScheduler;
   environment?: Record<string, string>;
@@ -72,6 +73,7 @@ export class Activities extends Construct implements IActivities, IGrantable {
     });
 
     this.worker = new ServiceFunction(this, "Worker", {
+      functionName: `${props.serviceName}-activity-handler`,
       serviceType: ServiceType.ActivityWorker,
       memorySize: 512,
       // retry attempts should be handled with a new request and a new retry count in accordance with the user's retry policy.

--- a/packages/@eventual/aws-cdk/src/events.ts
+++ b/packages/@eventual/aws-cdk/src/events.ts
@@ -59,6 +59,7 @@ export class Events extends Construct implements IGrantable {
     this.deadLetterQueue = new Queue(this, "DeadLetterQueue");
 
     this.handler = new ServiceFunction(this, "Handler", {
+      functionName: `${props.serviceName}-event-handler`,
       serviceType: ServiceType.EventHandler,
       deadLetterQueueEnabled: true,
       deadLetterQueue: this.deadLetterQueue,

--- a/packages/@eventual/aws-cdk/src/logging.ts
+++ b/packages/@eventual/aws-cdk/src/logging.ts
@@ -5,8 +5,13 @@ import { IGrantable } from "aws-cdk-lib/aws-iam";
 import { Function } from "aws-cdk-lib/aws-lambda";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { Construct } from "constructs";
+import type { Service } from "./service";
 
 export interface LoggingProps {
+  /**
+   * The name of the {@link Service} this {@link Logging} belongs to.
+   */
+  serviceName: string;
   /**
    * Optionally provide a log group.
    *
@@ -37,6 +42,7 @@ export class Logging extends Construct {
       props.logGroup ??
       new LogGroup(this, "group", {
         removalPolicy: RemovalPolicy.DESTROY,
+        logGroupName: `${props.serviceName}-execution-logs`,
       });
   }
 

--- a/packages/@eventual/aws-cdk/src/service-api.ts
+++ b/packages/@eventual/aws-cdk/src/service-api.ts
@@ -41,6 +41,7 @@ export class Api extends Construct {
     super(scope, id);
 
     this.handler = new ServiceFunction(this, "Handler", {
+      functionName: `${props.serviceName}-api-handler`,
       serviceType: ServiceType.ApiHandler,
       memorySize: 512,
       environment: props.environment,

--- a/packages/@eventual/aws-cdk/src/service.ts
+++ b/packages/@eventual/aws-cdk/src/service.ts
@@ -89,7 +89,7 @@ export interface ServiceProps {
    * @see WorkflowsProps
    */
   workflows?: Pick<WorkflowsProps, "orchestrator">;
-  logging?: LoggingProps;
+  logging?: Omit<LoggingProps, "serviceName">;
 }
 
 export class Service extends Construct implements IGrantable {
@@ -202,7 +202,10 @@ export class Service extends Construct implements IGrantable {
     const proxyWorkflows = lazyInterface<IWorkflows>();
     const proxyActivities = lazyInterface<IActivities>();
 
-    this.logging = new Logging(this, "logging", props.logging ?? {});
+    this.logging = new Logging(this, "logging", {
+      ...(props.logging ?? {}),
+      serviceName: this.serviceName,
+    });
 
     this.events = new Events(this, "Events", {
       appSpec: this.appSpec,
@@ -213,6 +216,7 @@ export class Service extends Construct implements IGrantable {
     });
 
     this.activities = new Activities(this, "Activities", {
+      serviceName: this.serviceName,
       scheduler: proxyScheduler,
       workflows: proxyWorkflows,
       environment: props.environment,
@@ -222,6 +226,7 @@ export class Service extends Construct implements IGrantable {
     proxyActivities._bind(this.activities);
 
     this.workflows = new Workflows(this, "Workflows", {
+      serviceName: this.serviceName,
       scheduler: proxyScheduler,
       activities: this.activities,
       table: this.table,

--- a/packages/@eventual/aws-cdk/src/workflows.ts
+++ b/packages/@eventual/aws-cdk/src/workflows.ts
@@ -21,6 +21,7 @@ import { ServiceFunction } from "./service-function";
 import { addEnvironment } from "./utils";
 
 export interface WorkflowsProps {
+  serviceName: string;
   scheduler: IScheduler;
   activities: IActivities;
   table: ITable;
@@ -81,6 +82,7 @@ export class Workflows extends Construct implements IWorkflows, IGrantable {
     });
 
     this.orchestrator = new ServiceFunction(this, "Orchestrator", {
+      functionName: `${props.serviceName}-orchestrator-handler`,
       serviceType: ServiceType.OrchestratorWorker,
       events: [
         new SqsEventSource(this.queue, {


### PR DESCRIPTION
- [x] give the API, Event, Activity, Orchestrator Lambdas
- [x] give a physical name to the Execution Log Group
- [x] add `typescript` dependency to generated template
- [x] generate a `README.md` file in the project template with information on the infrastructure, noteworthy Lambdas and Log Groups and useful scripts
- [x] add an `onEvent` example to the generated template
- [x] remove the choice of both `projectName` and `serviceName` in the getting started guide - just use the project name as the initial service name