### PR TITLE
fix: configure @types/jest at root to avoid vs code confusion

### DIFF
--- a/packages/@eventual/project/src/create-new-service.ts
+++ b/packages/@eventual/project/src/create-new-service.ts
@@ -102,7 +102,6 @@ export async function createServicePackage(
         },
         devDependencies: {
           "@eventual/testing": `^${props.eventualVersion}`,
-          "@types/jest": "^29",
           esbuild: "^0.16.14",
           jest: "^29",
           "ts-jest": "^29",
@@ -140,7 +139,6 @@ export async function createServicePackage(
         include: ["src", "test"],
         exclude: ["lib", "node_modules"],
         compilerOptions: {
-          types: ["@types/node", "@types/jest"],
           noEmit: true,
           rootDir: ".",
         },

--- a/packages/create-eventual/src/create-new-aws-cdk-project.ts
+++ b/packages/create-eventual/src/create-new-aws-cdk-project.ts
@@ -176,6 +176,7 @@ ${npm("deploy")}
         devDependencies: {
           "@eventual/cli": `^${version}`,
           "@tsconfig/node16": "^1",
+          "@types/jest": "^29",
           "@types/node": "^16",
           esbuild: "^0.16.14",
           typescript: "^4.9.4",
@@ -201,22 +202,17 @@ ${npm("deploy")}
           module: "esnext",
           moduleResolution: "NodeNext",
           resolveJsonModule: true,
-          types: ["@types/node"],
+          types: ["@types/node", "@types/jest"],
         },
       }),
       writeJsonFile("tsconfig.json", {
         files: [],
         references: [
           { path: `${appsDirName}/${serviceName}` },
+          { path: `${appsDirName}/${serviceName}/tsconfig.test.json` },
           { path: infraDirName },
           { path: `${packagesDirName}/events` },
         ],
-      }),
-      writeJsonFile("jest.config.base.json", {
-        preset: "ts-jest",
-        transform: {
-          "^.+\\.(t|j)sx?$": "ts-jest",
-        },
       }),
       fs.writeFile(
         ".gitignore",
@@ -438,7 +434,6 @@ helloEvent.onEvent(async (hello) => {
         "hello.test.ts": `import { Execution, ExecutionStatus } from "@eventual/core";
 import { TestEnvironment } from "@eventual/testing";
 import { createRequire } from "module";
-import path from "path";
 import { helloWorkflow } from "../src/index.js";
 
 const require = createRequire(import.meta.url);
@@ -449,7 +444,6 @@ let env: TestEnvironment;
 beforeAll(async () => {
   env = new TestEnvironment({
     entry: require.resolve("../src"),
-    outDir: path.resolve(".eventual"),
   });
 
   await env.initialize();
@@ -517,7 +511,6 @@ export const helloEvent = event<HelloEvent>("HelloEvent");
         },
         devDependencies: {
           "@eventual/core": version,
-          "@types/jest": "^29",
           jest: "^29",
           "ts-jest": "^29",
           typescript: "^4.9.4",
@@ -555,7 +548,6 @@ export const helloEvent = event<HelloEvent>("HelloEvent");
         include: ["src", "test"],
         exclude: ["lib", "node_modules"],
         compilerOptions: {
-          types: ["@types/node", "@types/jest"],
           noEmit: true,
           rootDir: ".",
         },


### PR DESCRIPTION
VS code was getting confused. Project built fine but VS code complained about jest types not being found. Workaround was to have the user import `@jest/types` at the root of every test but that's high friction. 

Another workaround seems to be to configure `@types/jest` at the root `tsconfig.base.json` instead of in child projects. This has the side effect of adding those types to all .ts files in all projects, but that was true of any project using tests anyway - so am going with this solution.

This new approach also removes redundancy in our package.json files - now `@types/jest` is only at the root, not in every package as a dev dependency. So double win.

Also remove unused `jest.config.base.json` - a failed experiment. I'd still like to remove redundant jest configuration using a `jest.config.ts` at the root - will do that in another pass.