### PR TITLE
fix(timeline): encoding

### DIFF
--- a/packages/@eventual/cli/src/commands/timeline.ts
+++ b/packages/@eventual/cli/src/commands/timeline.ts
@@ -12,6 +12,7 @@ import {
   encodeExecutionId,
   isWorkflowStarted,
   WorkflowStarted,
+  decodeExecutionId,
 } from "@eventual/core";
 import path from "path";
 
@@ -34,7 +35,8 @@ export const timeline = (yargs: Argv) =>
         // We forward errors onto our handler for the ui to deal with
         try {
           const { events } = await serviceClient.getExecutionWorkflowHistory(
-            req.params.execution
+            // execution id is encoded and will be re-encoded by the client.
+            decodeExecutionId(req.params.execution)
           );
           const timeline = aggregateEvents(events);
           res.json(timeline);


### PR DESCRIPTION
Small bug in the timeline ui. Was encoding twice. Now we encode on the ui, decode in the express api, and then re-encode in the client.