### PR TITLE
fix: properly use an entity's string name in the CDK types

### DIFF
--- a/apps/tests/aws-runtime-cdk/src/app.ts
+++ b/apps/tests/aws-runtime-cdk/src/app.ts
@@ -13,7 +13,7 @@ import { Queue } from "aws-cdk-lib/aws-sqs";
 import path from "path";
 import { ChaosExtension } from "./chaos-extension";
 
-import * as testServiceRuntime from "tests-runtime";
+import type * as testServiceRuntime from "tests-runtime";
 
 const app = new App();
 

--- a/packages/@eventual/aws-cdk/src/service.ts
+++ b/packages/@eventual/aws-cdk/src/service.ts
@@ -34,7 +34,7 @@ import { BuildOutput, buildServiceSync } from "./build";
 import {
   CommandProps,
   CommandService,
-  ServiceCommands,
+  Commands,
   SystemCommands,
 } from "./command-service";
 import { DeepCompositePrincipal } from "./deep-composite-principal.js";
@@ -141,7 +141,7 @@ export class Service<S = any> extends Construct {
   /**
    * Commands defined by the service.
    */
-  public readonly commands: ServiceCommands<S>;
+  public readonly commands: Commands<S>;
   /**
    * API Gateway which serves the service commands and the system commands.
    */

--- a/packages/@eventual/aws-cdk/src/subscriptions.ts
+++ b/packages/@eventual/aws-cdk/src/subscriptions.ts
@@ -13,16 +13,17 @@ import type { EventService } from "./event-service";
 import { LazyInterface } from "./proxy-construct";
 import type { ServiceConstructProps } from "./service";
 import { ServiceFunction } from "./service-function";
-import type { KeysOfType } from "./utils";
+import type { ServiceEntityProps } from "./utils";
 
-export type SubscriptionNames<Service> = KeysOfType<
+export type Subscriptions<Service> = ServiceEntityProps<
   Service,
-  { kind: "Subscription" }
+  "Subscription",
+  Subscription
 >;
 
-export type SubscriptionOverrides<Service> = {
-  [eventHandler in SubscriptionNames<Service>]?: SubscriptionHandlerProps;
-};
+export type SubscriptionOverrides<Service> = Partial<
+  ServiceEntityProps<Service, "Subscription", SubscriptionHandlerProps>
+>;
 
 export interface SubscriptionHandlerProps
   extends Omit<Partial<FunctionProps>, "code" | "handler" | "functionName"> {}
@@ -39,12 +40,6 @@ export interface SubscriptionsProps<S = any> extends ServiceConstructProps {
   readonly commandService: LazyInterface<CommandService>;
 }
 
-export type Subscriptions<Service> = {
-  [subscriptionName in keyof Pick<
-    Service,
-    SubscriptionNames<Service>
-  >]: Subscription;
-};
 export const Subscriptions: {
   new <Service>(props: SubscriptionsProps<Service>): Subscriptions<Service>;
 } = class Subscriptions<Service> {
@@ -67,7 +62,7 @@ export const Subscriptions: {
             subscription: sub,
             overrides:
               props.subscriptions?.[
-                sub.spec.name as SubscriptionNames<Service>
+                sub.spec.name as keyof SubscriptionOverrides<Service>
               ],
           }),
         ];


### PR DESCRIPTION
We were using the name of the export instead of the string name for the CDK types.