### PR TITLE
fix: command bugs

### DIFF
--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -471,6 +471,10 @@ export const allCommands = workflow("allCommands", async (_, context) => {
   return { signalCount: n };
 });
 
+export const hello3 = api.post("/hello3", () => {
+  return new HttpResponse("hello?");
+});
+
 export const helloApi = command(
   "helloApi",
   {

--- a/packages/@eventual/aws-cdk/src/command-service.ts
+++ b/packages/@eventual/aws-cdk/src/command-service.ts
@@ -286,10 +286,7 @@ export class CommandService<Service = any> {
           if (command.path) {
             self.gateway.addRoutes({
               // itty router supports paths in the form /*, but api gateway expects them in the form /{proxy+}
-              path:
-                command.path === "*"
-                  ? "/{proxy+}"
-                  : (command.path as string).replace(/\*/g, "{proxy+}"),
+              path: ittyRouteToApigatewayRoute(command.path),
               methods: [
                 (command.method as HttpMethod | undefined) ?? HttpMethod.GET,
               ],
@@ -456,6 +453,12 @@ export class CommandService<Service = any> {
   private addEnvs(func: Function, ...envs: (keyof typeof this.ENV_MAPPINGS)[]) {
     envs.forEach((env) => func.addEnvironment(env, this.ENV_MAPPINGS[env]()));
   }
+}
+
+function ittyRouteToApigatewayRoute(route: string) {
+  return route === "*"
+    ? "/{proxy+}"
+    : route.replace(/\*/g, "{proxy+}").replaceAll(/\:([^\/]*)/g, "{$1}");
 }
 
 interface SynthesizedCommand {


### PR DESCRIPTION
* [x] Bug: /rpc path was being created for low level http APIs and not api gateway
   * [x] removed the internal RPC path
* [x] Bug: variable paths were not being correctly converted to api gateway variable paths
   * itty: `/:userId`
   * apig: `/{userId}`


Current state of commands and apis:

||Creates RPC Command|service client method|rest path|access to http headers|
|----|---|---|---|---|
|Command (`command()` or `api.command()`)| ✅ |✅ | |
|Command with Path(`command()` or `api.command()`)|✅ |✅ |✅ |✅ |
|Low Level Http (`api.[get/put/option/etc]`)|||✅ |✅ |