### PR TITLE
fix: entity list throws dynamo error

### DIFF
--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -622,6 +622,7 @@ export const entityWorkflow = workflow(
     ]);
     // send deletion, to be picked up by the stream
     counter.delete(id);
+    await counter.list({});
     // this signal will contain the final value after deletion
     return await entitySignal2.expectSignal();
   }

--- a/packages/@eventual/aws-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/aws-runtime/src/stores/entity-store.ts
@@ -51,7 +51,11 @@ export class AWSEntityStore implements EntityStore {
       new GetItemCommand({
         Key: this.entityKey(_key),
         TableName: this.tableName(name),
-        AttributesToGet: ["value", "version"],
+        ProjectionExpression: "#value,#version",
+        ExpressionAttributeNames: {
+          "#version": "version",
+          "#value": "value",
+        },
         ConsistentRead: true,
       })
     );
@@ -291,7 +295,10 @@ export class AWSEntityStore implements EntityStore {
           ":pk": { S: EntityEntityRecord.key(request.namespace) },
           ":sk": { S: EntityEntityRecord.sortKey(request.prefix ?? "") },
         },
-        AttributesToGet: fields,
+        ExpressionAttributeNames: fields
+          ? Object.fromEntries(fields?.map((f) => [`#${f}`, f]))
+          : undefined,
+        ProjectionExpression: fields?.map((f) => `#${f}`).join(","),
       }
     );
   }


### PR DESCRIPTION
`AttributesToGet` is a legacy field and fails when run with not legacy `KeyConditionExpression`.

Added `list` to the tests.