### PR TITLE
feat: service content in handlers

### DIFF
--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -764,8 +764,9 @@ export const specCommand = command(
 );
 
 export const extractHeaderCommand = api
-  .use(({ request, next }) =>
+  .use(({ request, context, next }) =>
     next({
+      ...context,
       MyHeader: request.headers.get("MyHeader"),
     })
   )
@@ -802,6 +803,10 @@ export const modifyResponseMiddlewareHttp = api
   .get("/modify-response-http", async () => {
     return new HttpResponse("My Response");
   });
+
+export const contextTest = command("contextText", (_, { service }) => {
+  return service;
+});
 
 const simpleEvent = event<{ value: string }>("simpleEvent");
 

--- a/apps/tests/aws-runtime/test/tester.test.ts
+++ b/apps/tests/aws-runtime/test/tester.test.ts
@@ -3,6 +3,7 @@ import {
   commandRpcPath,
   EventualError,
   HeartbeatTimeout,
+  ServiceContext,
 } from "@eventual/core";
 import { jest } from "@jest/globals";
 import { ChaosEffects, ChaosTargets } from "./chaos-extension/chaos-engine.js";
@@ -242,7 +243,7 @@ test("middleware context is properly piped to command", async () => {
     })
   ).json();
 
-  expect(rpcResponse).toEqual({
+  expect(rpcResponse).toMatchObject({
     MyHeader: "value",
   });
 });
@@ -285,4 +286,17 @@ test("middleware can edit response", async () => {
   );
 
   expect(rpcResponse.headers.get("ModifiedHeader")).toEqual("Injected Header");
+});
+
+test("test service context", async () => {
+  const serviceClient = new ServiceClient<typeof TestService>({
+    serviceUrl: url,
+  });
+
+  await expect(
+    serviceClient.contextText()
+  ).resolves.toMatchObject<ServiceContext>({
+    serviceName: "eventual-tests",
+    serviceUrl: url,
+  });
 });

--- a/packages/@eventual/aws-cdk/src/service-function.ts
+++ b/packages/@eventual/aws-cdk/src/service-function.ts
@@ -1,4 +1,4 @@
-import { serviceFunctionName } from "@eventual/aws-runtime";
+import { ENV_NAMES, serviceFunctionName } from "@eventual/aws-runtime";
 import type { FunctionRuntimeProps } from "@eventual/core";
 import {
   BundledFunction,
@@ -55,6 +55,7 @@ export class ServiceFunction extends Function {
           : props.defaults?.timeout ?? Duration.seconds(3)),
       environment: {
         NODE_OPTIONS: "--enable-source-maps",
+        [ENV_NAMES.SERVICE_NAME]: props.build.serviceName,
         ...baseFnProps.environment,
         ...props.defaults?.environment,
         ...props.overrides?.environment,

--- a/packages/@eventual/aws-runtime/src/handlers/apig-command-adapter.ts
+++ b/packages/@eventual/aws-runtime/src/handlers/apig-command-adapter.ts
@@ -1,9 +1,11 @@
 import { EventualServiceClient, HttpMethod, HttpRequest } from "@eventual/core";
 import {
+  getLazy,
+  LazyValue,
   registerWorkerIntrinsics,
   type CommandWorker,
 } from "@eventual/core-runtime";
-import { ServiceSpec } from "@eventual/core/internal";
+import type { ServiceSpec } from "@eventual/core/internal";
 import type {
   APIGatewayProxyEventV2,
   APIGatewayProxyHandlerV2,
@@ -21,16 +23,19 @@ export function createApiGCommandAdaptor({
   commandWorker,
   serviceClientBuilder,
   serviceSpec,
+  serviceName: _serviceName,
 }: {
   commandWorker: CommandWorker;
+  serviceName: LazyValue<string>;
   serviceSpec?: ServiceSpec;
   serviceClientBuilder?: (serviceUrl: string) => EventualServiceClient;
 }): APIGatewayProxyHandlerV2 {
+  const serviceName = getLazy(_serviceName);
   return async function (
     event: APIGatewayProxyEventV2
   ): Promise<APIGatewayProxyResultV2> {
     console.debug("event", event);
-    //
+
     const serviceUrl = `https://${event.requestContext.domainName}`;
     const serviceClient = serviceClientBuilder
       ? serviceClientBuilder(serviceUrl)
@@ -38,7 +43,8 @@ export function createApiGCommandAdaptor({
     registerWorkerIntrinsics({
       serviceClient,
       serviceSpec,
-      serviceUrls: [serviceUrl],
+      serviceUrl,
+      serviceName: getLazy(serviceName),
     });
     const requestBody = event.body
       ? event.isBase64Encoded
@@ -56,7 +62,9 @@ export function createApiGCommandAdaptor({
       }
     );
 
-    const response = await commandWorker(request);
+    const response = await commandWorker(request, {
+      service: { serviceUrl, serviceName },
+    });
     const headers: Record<string, string> = {};
 
     response.headers.forEach((value, key) => (headers[key] = value));

--- a/packages/@eventual/aws-runtime/src/handlers/command-worker.ts
+++ b/packages/@eventual/aws-runtime/src/handlers/command-worker.ts
@@ -9,6 +9,7 @@ import {
   createTransactionClient,
 } from "../create.js";
 import { createApiGCommandAdaptor } from "./apig-command-adapter.js";
+import { serviceName } from "../env.js";
 
 /**
  * Handle inbound command and rest api requests.
@@ -20,7 +21,9 @@ export default createApiGCommandAdaptor({
   commandWorker: createCommandWorker({
     // the service client, spec, and service url will be created at runtime, using a computed uri from the apigateway request
     entityClient: createEntityClient(),
+    serviceName,
   }),
+  serviceName,
   serviceSpec,
   // pulls the service url from the request instead of env variables to reduce the circular dependency between commands and the gateway.
   serviceClientBuilder: (serviceUrl) =>

--- a/packages/@eventual/aws-runtime/src/handlers/entity-stream-worker.ts
+++ b/packages/@eventual/aws-runtime/src/handlers/entity-stream-worker.ts
@@ -11,14 +11,20 @@ import {
 import { EntityStreamOperation } from "@eventual/core/internal";
 import { DynamoDBStreamHandler } from "aws-lambda";
 import { createEntityClient, createServiceClient } from "../create.js";
-import { entityName, entityStreamName, serviceUrl } from "../env.js";
+import {
+  entityName,
+  entityStreamName,
+  serviceName,
+  serviceUrl,
+} from "../env.js";
 import { EntityEntityRecord } from "../stores/entity-store.js";
 
 const worker = createEntityStreamWorker({
   serviceClient: createServiceClient({}),
   entityClient: createEntityClient(),
   serviceSpec,
-  serviceUrls: [serviceUrl],
+  serviceName,
+  serviceUrl,
 });
 
 export default (async (event) => {

--- a/packages/@eventual/aws-runtime/src/handlers/subscription-worker.ts
+++ b/packages/@eventual/aws-runtime/src/handlers/subscription-worker.ts
@@ -12,7 +12,7 @@ import {
   createServiceClient,
   createTransactionClient,
 } from "../create.js";
-import { serviceUrl } from "../env.js";
+import { serviceName, serviceUrl } from "../env.js";
 
 export const processEvent = createSubscriptionWorker({
   // partially uses the runtime clients and partially uses the http client
@@ -23,7 +23,8 @@ export const processEvent = createSubscriptionWorker({
   subscriptionProvider: new GlobalSubscriptionProvider(),
   entityClient: createEntityClient(),
   serviceSpec,
-  serviceUrls: [serviceUrl],
+  serviceName,
+  serviceUrl: serviceUrl,
 });
 
 export default async function (event: EventBridgeEvent<string, any>) {

--- a/packages/@eventual/aws-runtime/src/handlers/system-command-handler.ts
+++ b/packages/@eventual/aws-runtime/src/handlers/system-command-handler.ts
@@ -3,13 +3,13 @@ import serviceSpec from "@eventual/injected/spec";
 import type { AnyCommand } from "@eventual/core";
 import {
   createCommandWorker,
+  createEmitEventsCommand,
   createExecuteTransactionCommand,
   createGetExecutionCommand,
   createListExecutionHistoryCommand,
   createListExecutionsCommand,
   createListWorkflowHistoryCommand,
   createListWorkflowsCommand,
-  createEmitEventsCommand,
   createSendSignalCommand,
   createStartExecutionCommand,
   createUpdateTaskCommand,
@@ -26,13 +26,16 @@ import {
   createTransactionClient,
   createWorkflowClient,
 } from "../create.js";
+import { serviceName } from "../env.js";
 import { createApiGCommandAdaptor } from "./apig-command-adapter.js";
 
 function systemCommandWorker(
   ..._commands: AnyCommand[]
 ): APIGatewayProxyHandlerV2<Response> {
   return createApiGCommandAdaptor({
-    commandWorker: createCommandWorker({ serviceSpec }),
+    commandWorker: createCommandWorker({}),
+    serviceSpec,
+    serviceName,
   });
 }
 

--- a/packages/@eventual/aws-runtime/src/handlers/task-worker.ts
+++ b/packages/@eventual/aws-runtime/src/handlers/task-worker.ts
@@ -3,10 +3,10 @@ import serviceSpec from "@eventual/injected/spec";
 import "@eventual/injected/entry";
 
 import {
+  createTaskWorker,
   GlobalTaskProvider,
   TaskFallbackRequest,
   TaskWorkerRequest,
-  createTaskWorker,
 } from "@eventual/core-runtime";
 import { AWSMetricsClient } from "../clients/metrics-client.js";
 import {
@@ -24,11 +24,11 @@ import {
 import { serviceName, serviceUrl } from "../env.js";
 
 const worker = createTaskWorker({
-  executionQueueClient: createExecutionQueueClient(),
+  entityClient: createEntityClient(),
   eventClient: createEventClient(),
-  timerClient: createTimerClient(),
+  executionQueueClient: createExecutionQueueClient(),
+  logAgent: createLogAgent(),
   metricsClient: AWSMetricsClient,
-  taskProvider: new GlobalTaskProvider(),
   // partially uses the runtime clients and partially uses the http client
   serviceClient: createServiceClient({
     taskClient: createTaskClient(),
@@ -38,12 +38,12 @@ const worker = createTaskWorker({
     executionStore: createExecutionStore(),
     transactionClient: createTransactionClient(),
   }),
-  logAgent: createLogAgent(),
-  taskStore: createTaskStore(),
-  serviceName: serviceName(),
-  entityClient: createEntityClient(),
+  serviceName,
   serviceSpec,
-  serviceUrls: [serviceUrl],
+  serviceUrl,
+  taskProvider: new GlobalTaskProvider(),
+  taskStore: createTaskStore(),
+  timerClient: createTimerClient(),
 });
 
 export default async (request: TaskWorkerRequest) => {

--- a/packages/@eventual/aws-runtime/src/handlers/transaction-worker.ts
+++ b/packages/@eventual/aws-runtime/src/handlers/transaction-worker.ts
@@ -5,11 +5,13 @@ import { createTransactionWorker } from "@eventual/core-runtime";
 import {
   createEntityStore,
   createEventClient,
-  createExecutionQueueClient,
+  createExecutionQueueClient
 } from "../create.js";
+import { serviceName } from "../env.js";
 
 export default createTransactionWorker({
   entityStore: createEntityStore(),
   eventClient: createEventClient(),
   executionQueueClient: createExecutionQueueClient(),
+  serviceName,
 });

--- a/packages/@eventual/cli/src/commands/local.ts
+++ b/packages/@eventual/cli/src/commands/local.ts
@@ -114,7 +114,8 @@ export const local = (yargs: Argv) =>
       // TODO: should the loading be done by the local env?
       const localEnv = new LocalEnvironment({
         serviceSpec,
-        serviceUrls: [url],
+        serviceUrl: url,
+        serviceName: serviceName,
       });
 
       app.use(express.json({ strict: false }));

--- a/packages/@eventual/core-runtime/src/handlers/entity-stream-worker.ts
+++ b/packages/@eventual/core-runtime/src/handlers/entity-stream-worker.ts
@@ -2,8 +2,9 @@ import { EntityStreamItem } from "@eventual/core";
 import {
   ServiceType,
   entities,
-  serviceTypeScope
+  serviceTypeScope,
 } from "@eventual/core/internal";
+import { getLazy } from "../utils.js";
 import { WorkerIntrinsicDeps, registerWorkerIntrinsics } from "./utils.js";
 
 export interface EntityStreamWorker {
@@ -15,7 +16,7 @@ interface EntityStreamWorkerDependencies extends WorkerIntrinsicDeps {}
 export function createEntityStreamWorker(
   dependencies: EntityStreamWorkerDependencies
 ): EntityStreamWorker {
-  registerWorkerIntrinsics(dependencies)
+  registerWorkerIntrinsics(dependencies);
 
   return async (item) =>
     serviceTypeScope(ServiceType.EntityStreamWorker, async () => {
@@ -25,6 +26,11 @@ export function createEntityStreamWorker(
       if (!streamHandler) {
         throw new Error(`Stream handler ${item.streamName} does not exist`);
       }
-      return await streamHandler.handler(item);
+      return await streamHandler.handler(item, {
+        service: {
+          serviceName: getLazy(dependencies.serviceName),
+          serviceUrl: getLazy(dependencies.serviceUrl),
+        },
+      });
     });
 }

--- a/packages/@eventual/core-runtime/src/handlers/subscription-worker.ts
+++ b/packages/@eventual/core-runtime/src/handlers/subscription-worker.ts
@@ -1,7 +1,11 @@
 import { EventEnvelope } from "@eventual/core";
 import { ServiceType, serviceTypeScope } from "@eventual/core/internal";
 import { SubscriptionProvider } from "../providers/subscription-provider.js";
-import { WorkerIntrinsicDeps, registerWorkerIntrinsics } from "./utils.js";
+import {
+  WorkerIntrinsicDeps,
+  registerWorkerIntrinsics,
+  getServiceContext,
+} from "./utils.js";
 
 /**
  * The dependencies of {@link createSubscriptionWorker}.
@@ -35,7 +39,9 @@ export function createSubscriptionWorker(
           Promise.allSettled(
             deps.subscriptionProvider
               .getSubscriptionsForEvent(event.name)
-              .map((handler) => handler(event.event))
+              .map((handler) =>
+                handler(event.event, { service: getServiceContext(deps) })
+              )
           )
         )
       );

--- a/packages/@eventual/core-runtime/src/handlers/transaction-worker.ts
+++ b/packages/@eventual/core-runtime/src/handlers/transaction-worker.ts
@@ -1,18 +1,20 @@
-import {
+import type {
   ExecuteTransactionRequest,
   ExecuteTransactionResponse,
 } from "@eventual/core";
 import { transactions } from "@eventual/core/internal";
-import { EventClient } from "../clients/event-client.js";
-import { ExecutionQueueClient } from "../clients/execution-queue-client.js";
+import type { EventClient } from "../clients/event-client.js";
+import type { ExecutionQueueClient } from "../clients/execution-queue-client.js";
 import { isResolved } from "../result.js";
-import { EntityStore } from "../stores/entity-store.js";
+import type { EntityStore } from "../stores/entity-store.js";
 import { createTransactionExecutor } from "../transaction-executor.js";
+import { getLazy, LazyValue } from "../utils.js";
 
 export interface TransactionWorkerProps {
   entityStore: EntityStore;
   executionQueueClient: ExecutionQueueClient;
   eventClient: EventClient;
+  serviceName: LazyValue<string>;
 }
 
 export interface TransactionWorker {
@@ -45,6 +47,11 @@ export function createTransactionWorker(
     const output = await transactionExecutor(
       transaction?.handler,
       request.input,
+      {
+        service: {
+          serviceName: getLazy(props.serviceName),
+        },
+      },
       // max retries
       100
     );

--- a/packages/@eventual/core-runtime/src/handlers/utils.ts
+++ b/packages/@eventual/core-runtime/src/handlers/utils.ts
@@ -1,18 +1,19 @@
-import { EventualServiceClient } from "@eventual/core";
+import type { EventualServiceClient, ServiceContext } from "@eventual/core";
 import {
-  ServiceSpec,
   registerEntityHook,
   registerEnvironmentManifest,
   registerServiceClient,
+  ServiceSpec,
 } from "@eventual/core/internal";
 import { EntityClient } from "../clients/entity-client.js";
-import { LazyValue, getLazy } from "../utils.js";
+import { getLazy, LazyValue } from "../utils.js";
 
 export interface WorkerIntrinsicDeps {
   entityClient?: EntityClient;
   serviceClient?: EventualServiceClient;
-  serviceUrls?: (string | LazyValue<string>)[];
+  serviceName: string | LazyValue<string>;
   serviceSpec?: ServiceSpec;
+  serviceUrl: string | LazyValue<string>;
 }
 
 export function registerWorkerIntrinsics(deps: WorkerIntrinsicDeps) {
@@ -25,7 +26,15 @@ export function registerWorkerIntrinsics(deps: WorkerIntrinsicDeps) {
   if (deps.serviceSpec) {
     registerEnvironmentManifest({
       serviceSpec: deps.serviceSpec,
-      serviceUrls: (deps.serviceUrls ?? []).map(getLazy),
+      serviceUrl: getLazy(deps.serviceUrl),
+      serviceName: getLazy(deps.serviceName),
     });
   }
+}
+
+export function getServiceContext(deps: WorkerIntrinsicDeps): ServiceContext {
+  return {
+    serviceName: getLazy(deps.serviceName),
+    serviceUrl: getLazy(deps.serviceUrl),
+  };
 }

--- a/packages/@eventual/core-runtime/src/local/local-container.ts
+++ b/packages/@eventual/core-runtime/src/local/local-container.ts
@@ -88,6 +88,7 @@ export type LocalEvent =
 export interface LocalContainerProps {
   taskProvider?: TaskProvider;
   serviceName: string;
+  serviceUrl: string;
   subscriptionProvider?: SubscriptionProvider;
 }
 
@@ -148,6 +149,8 @@ export class LocalContainer {
     this.subscriptionWorker = createSubscriptionWorker({
       subscriptionProvider: this.subscriptionProvider,
       entityClient,
+      serviceName: props.serviceName,
+      serviceUrl: props.serviceUrl,
     });
     this.eventClient = new LocalEventClient(this.subscriptionWorker);
     this.metricsClient = new LocalMetricsClient();
@@ -165,6 +168,7 @@ export class LocalContainer {
       logAgent,
       metricsClient: this.metricsClient,
       serviceName: props.serviceName,
+      serviceUrl: props.serviceUrl,
       timerClient: this.timerClient,
       entityClient,
     });
@@ -176,12 +180,15 @@ export class LocalContainer {
 
     this.entityStreamWorker = createEntityStreamWorker({
       entityClient,
+      serviceName: props.serviceName,
+      serviceUrl: props.serviceUrl,
     });
 
     this.transactionWorker = createTransactionWorker({
       entityStore,
       eventClient: this.eventClient,
       executionQueueClient: this.executionQueueClient,
+      serviceName: props.serviceName,
     });
 
     this.transactionClient = new LocalTransactionClient(this.transactionWorker);
@@ -238,7 +245,11 @@ export class LocalContainer {
     });
 
     // must register commands before the command worker is loaded!
-    this.commandWorker = createCommandWorker({ entityClient });
+    this.commandWorker = createCommandWorker({
+      entityClient,
+      serviceName: props.serviceName,
+      serviceUrl: props.serviceUrl,
+    });
 
     this.timerHandler = createTimerHandler({
       taskStore: this.taskStore,

--- a/packages/@eventual/core-runtime/src/local/local-environment.ts
+++ b/packages/@eventual/core-runtime/src/local/local-environment.ts
@@ -28,7 +28,7 @@ export class LocalEnvironment {
   private running: boolean = false;
   private localContainer: LocalContainer;
 
-  constructor(environmentManifest: EnvironmentManifest) {
+  constructor(private environmentManifest: EnvironmentManifest) {
     this.timeController = new TimeController([], {
       increment: 1,
       start: new Date().getTime(),
@@ -50,7 +50,8 @@ export class LocalEnvironment {
       },
     };
     this.localContainer = new LocalContainer(this.localConnector, {
-      serviceName: "fixme",
+      serviceName: environmentManifest.serviceName,
+      serviceUrl: environmentManifest.serviceUrl,
     });
 
     const serviceClient = new RuntimeServiceClient({
@@ -169,6 +170,11 @@ export class LocalEnvironment {
   public async invokeCommandOrApi(
     httpRequest: HttpRequest
   ): Promise<HttpResponse> {
-    return this.localContainer.commandWorker(httpRequest);
+    return this.localContainer.commandWorker(httpRequest, {
+      service: {
+        serviceUrl: this.environmentManifest.serviceUrl,
+        serviceName: this.environmentManifest.serviceName,
+      },
+    });
   }
 }

--- a/packages/@eventual/core/src/entity.ts
+++ b/packages/@eventual/core/src/entity.ts
@@ -15,6 +15,7 @@ import {
   isSourceLocation,
   SourceLocation,
 } from "./internal/service-spec.js";
+import type { ServiceContext } from "./service.js";
 
 export interface CompositeKey {
   namespace: string;
@@ -80,11 +81,21 @@ export interface EntitySetOptions extends EntityConsistencyOptions {
   incrementVersion?: boolean;
 }
 
+export interface EntityStreamContext {
+  /**
+   * Information about the containing service.
+   */
+  service: ServiceContext;
+}
+
 export interface EntityStreamHandler<Entity> {
   /**
-   * Provides the keys, new value\
+   * Provides the keys, new value
    */
-  (item: EntityStreamItem<Entity>): Promise<void | false> | void | false;
+  (item: EntityStreamItem<Entity>, context: EntityStreamContext):
+    | Promise<void | false>
+    | void
+    | false;
 }
 
 export interface EntityStreamItemBase {

--- a/packages/@eventual/core/src/http/api.ts
+++ b/packages/@eventual/core/src/http/api.ts
@@ -9,6 +9,7 @@ import {
   AnyCommand,
   Command,
   command,
+  CommandContext,
   CommandHandler,
   CommandOptions,
   parseCommandArgs,
@@ -20,7 +21,7 @@ import type {
 } from "./middleware.js";
 import type { HttpRequest, HttpResponse } from "./request-response.js";
 
-const router = itty.Router() as any as HttpRouter<{}>;
+const router = itty.Router() as any as HttpRouter<CommandContext>;
 
 /**
  * This Proxy intercepts the method  being called, e.g. `get`, `post`, etc.
@@ -33,9 +34,9 @@ const router = itty.Router() as any as HttpRouter<{}>;
  *
  * @see HttpRoute for all the metadata associated with each route
  */
-export const api: HttpRouter<{}> = createRouter([]);
+export const api: HttpRouter<CommandContext> = createRouter([]);
 
-function createRouter<Context>(
+function createRouter<Context extends CommandContext>(
   middlewares?: Middleware<any, any>[]
 ): HttpRouter<Context> {
   return new Proxy(
@@ -117,7 +118,7 @@ function createRouter<Context>(
 
 export interface RouteRuntimeProps extends FunctionRuntimeProps {}
 
-export type HttpHandler<Context = any> = (
+export type HttpHandler<Context extends CommandContext = CommandContext> = (
   request: HttpRequest,
   context: Context
 ) => HttpResponse | Promise<HttpResponse>;
@@ -133,7 +134,7 @@ export interface HttpRoute {
   sourceLocation?: SourceLocation;
 }
 
-export interface HttpRouteFactory<Context> {
+export interface HttpRouteFactory<Context extends CommandContext> {
   (
     path: string,
     props: RouteRuntimeProps,
@@ -142,7 +143,7 @@ export interface HttpRouteFactory<Context> {
   (path: string, handlers: HttpHandler<Context>): HttpRouter<Context>;
 }
 
-export interface HttpRouter<Context> {
+export interface HttpRouter<Context extends CommandContext> {
   handle: (request: HttpRequest, ...extra: any) => Promise<HttpResponse>;
   routes: HttpRouteEntry[];
   all: HttpRouteFactory<Context>;
@@ -155,7 +156,7 @@ export interface HttpRouter<Context> {
   options: HttpRouteFactory<Context>;
   trace: HttpRouteFactory<Context>;
   patch: HttpRouteFactory<Context>;
-  use<NextContext>(
+  use<NextContext extends CommandContext>(
     middleware: (
       input: MiddlewareInput<Context>
     ) => Promise<MiddlewareOutput<NextContext>> | MiddlewareOutput<NextContext>
@@ -195,7 +196,7 @@ export const ApiSpecification: ApiSpecification = {
       createRestPaths: true,
       createRpcPaths: options?.includeRpcPaths ?? false,
       info: envManifest.serviceSpec.openApi.info,
-      servers: envManifest.serviceUrls.map((s) => ({ url: s })),
+      servers: [{ url: envManifest.serviceUrl }],
     });
   },
 };

--- a/packages/@eventual/core/src/http/middleware.ts
+++ b/packages/@eventual/core/src/http/middleware.ts
@@ -1,9 +1,12 @@
+import { CommandContext } from "./command.js";
 import { HttpRequest, HttpResponse } from "./request-response.js";
 
 export interface MiddlewareInput<In> {
   request: HttpRequest;
   context: In;
-  next: <O>(context: O) => Promise<MiddlewareOutput<O>>;
+  // Middleware should maintain the base context form in the next context.
+  // The base context values can be modified/used.
+  next: <O extends CommandContext>(context: O) => Promise<MiddlewareOutput<O>>;
 }
 
 export interface MiddlewareOutput<Context> extends HttpResponse {
@@ -36,9 +39,10 @@ export type Middleware<In, Out> = (
  * @param fn
  * @returns
  */
-export function middleware<PrevContext = any, OutContext = any>(
-  fn: (input: MiddlewareInput<any>) => MiddlewareOutput<OutContext>
-) {
+export function middleware<
+  PrevContext extends CommandContext = CommandContext,
+  OutContext extends CommandContext = CommandContext
+>(fn: (input: MiddlewareInput<any>) => MiddlewareOutput<OutContext>) {
   return async <In extends PrevContext>(input: MiddlewareInput<In>) =>
     fn({
       ...input,

--- a/packages/@eventual/core/src/index.ts
+++ b/packages/@eventual/core/src/index.ts
@@ -12,6 +12,7 @@ export * from "./logging.js";
 export * from "./schedule.js";
 export * from "./secret.js";
 export * from "./service-client.js";
+export * from "./service.js";
 export * from "./signals.js";
 export * from "./subscription.js";
 export * from "./task.js";

--- a/packages/@eventual/core/src/internal/service-spec.ts
+++ b/packages/@eventual/core/src/internal/service-spec.ts
@@ -179,6 +179,7 @@ export interface TransactionSpec {
 }
 
 export interface EnvironmentManifest {
+  serviceName: string;
   serviceSpec: ServiceSpec;
-  serviceUrls: string[];
+  serviceUrl: string;
 }

--- a/packages/@eventual/core/src/internal/task.ts
+++ b/packages/@eventual/core/src/internal/task.ts
@@ -1,3 +1,4 @@
+import type { ServiceContext } from "../service.js";
 import type {
   AsyncResult,
   Task,
@@ -14,6 +15,7 @@ export const AsyncTokenSymbol = /* @__PURE__ */ Symbol.for(
 export interface TaskRuntimeContext {
   execution: TaskExecutionContext;
   invocation: TaskInvocationContext;
+  service: ServiceContext;
 }
 
 export type TaskInput<A extends Task<any, any>> = A extends Task<

--- a/packages/@eventual/core/src/service.ts
+++ b/packages/@eventual/core/src/service.ts
@@ -1,0 +1,10 @@
+export interface ServiceContext {
+  /**
+   * The name of the service.
+   */
+  serviceName: string;
+  /**
+   * The base url of the service API.
+   */
+  serviceUrl: string;
+}

--- a/packages/@eventual/core/src/subscription.ts
+++ b/packages/@eventual/core/src/subscription.ts
@@ -2,12 +2,21 @@ import type { Event, EventPayload } from "./event.js";
 import type { FunctionRuntimeProps } from "./function-props.js";
 import { subscriptions } from "./internal/global.js";
 import { isSourceLocation, SourceLocation } from "./internal/service-spec.js";
+import { ServiceContext } from "./service.js";
+
+export interface SubscriptionContext {
+  /**
+   *Information about the containing service.
+   */
+  service: ServiceContext;
+}
 
 /**
  * A Function that processes an {@link event} of type {@link E}.
  */
 export type SubscriptionHandler<E extends EventPayload> = (
-  event: E
+  event: E,
+  context: SubscriptionContext
 ) => Promise<void> | void;
 
 /**

--- a/packages/@eventual/core/src/task.ts
+++ b/packages/@eventual/core/src/task.ts
@@ -17,6 +17,7 @@ import type {
   EventualServiceClient,
   SendTaskHeartbeatResponse,
 } from "./service-client.js";
+import { ServiceContext } from "./service.js";
 
 export interface TaskRuntimeProps extends FunctionRuntimeProps {}
 
@@ -294,6 +295,7 @@ export function task<Name extends string, Input = any, Output = any>(
           },
           execution: runtimeContext.execution,
           invocation: runtimeContext.invocation,
+          service: runtimeContext.service,
         };
         // calling the task from outside the orchestrator just calls the handler
         return handler(input as Input, context);
@@ -360,4 +362,8 @@ export interface TaskContext {
    * Information about this specific invocation of the execution.
    */
   invocation: TaskInvocationContext;
+  /**
+   *Information about the containing service.
+   */
+  service: ServiceContext;
 }

--- a/packages/@eventual/core/src/transaction.ts
+++ b/packages/@eventual/core/src/transaction.ts
@@ -6,9 +6,17 @@ import {
 } from "./internal/calls.js";
 import { getServiceClient, transactions } from "./internal/global.js";
 import { TransactionSpec } from "./internal/service-spec.js";
+import { ServiceContext } from "./service.js";
+
+export interface TransactionContext {
+  /**
+   *Information about the containing service.
+   */
+  service: Omit<ServiceContext, "serviceUrl">;
+}
 
 export interface TransactionFunction<Input, Output> {
-  (input: Input, context: any): Promise<Output> | Output;
+  (input: Input, context: TransactionContext): Promise<Output> | Output;
 }
 
 export interface Transaction<Input = any, Output = any>

--- a/packages/@eventual/testing/src/environment.ts
+++ b/packages/@eventual/testing/src/environment.ts
@@ -105,8 +105,12 @@ export class TestEnvironment extends RuntimeServiceClient {
       getTime: () => this.time,
     };
 
+    const serviceName = props?.serviceName ?? "testing";
+    const serviceUrl = "unknown";
+
     const localContainer = new LocalContainer(localEnvConnector, {
-      serviceName: props?.serviceName ?? "testing",
+      serviceName,
+      serviceUrl,
       taskProvider: taskProvider,
       subscriptionProvider: subscriptionProvider,
     });
@@ -135,7 +139,9 @@ export class TestEnvironment extends RuntimeServiceClient {
       serviceSpec: inferFromMemory({
         info: { title: "test-service", version: "1" },
       }),
-      serviceUrls: [],
+      // TODO: support a local endpoint for local testing
+      serviceUrl,
+      serviceName,
     });
   }
 

--- a/packages/@eventual/testing/test/env.test.ts
+++ b/packages/@eventual/testing/test/env.test.ts
@@ -641,10 +641,13 @@ describe("events", () => {
       await env.emitEvent(continueEvent, {
         executionId: execution.executionId,
       });
-      expect(dataEventMock).toBeCalledWith({
-        executionId: execution.executionId,
-        data: "event data",
-      });
+      expect(dataEventMock).toBeCalledWith(
+        {
+          executionId: execution.executionId,
+          data: "event data",
+        },
+        expect.anything()
+      );
       expect(await execution.getStatus()).toMatchObject<Partial<Execution>>({
         status: ExecutionStatus.SUCCEEDED,
         result: "event data",
@@ -704,10 +707,13 @@ describe("events", () => {
       await env.emitEvent(continueEvent, {
         executionId: execution.executionId,
       });
-      expect(dataEventMock).toBeCalledWith({
-        executionId: execution.executionId,
-        data: "event data",
-      });
+      expect(dataEventMock).toBeCalledWith(
+        {
+          executionId: execution.executionId,
+          data: "event data",
+        },
+        expect.anything()
+      );
       expect(await execution.getStatus()).toMatchObject<Partial<Execution>>({
         status: ExecutionStatus.SUCCEEDED,
         result: "event data",
@@ -737,10 +743,13 @@ describe("events", () => {
         executionId: execution.executionId,
       });
       // the test env handler was called
-      expect(dataEventMock).toBeCalledWith({
-        executionId: execution.executionId,
-        data: "event data",
-      });
+      expect(dataEventMock).toBeCalledWith(
+        {
+          executionId: execution.executionId,
+          data: "event data",
+        },
+        expect.anything()
+      );
 
       // but the workflow was not progressed by the default subscriptions.
       expect(await execution.getStatus()).toMatchObject<Partial<Execution>>({


### PR DESCRIPTION
Adds `context.service.serviceName` and `context.service.serviceUrl` to most of the handlers.

Left out of workflows for now as the url may not be deterministic. Transactions will only get the name as the url is not currently send to it and transactions should not make API requests...

command and apis will now always have the CommandContext interface for a content, middleware can add to this interface or change values inside of it.