### PR TITLE
feat: entity index

### DIFF
--- a/apps/test-app-runtime/package.json
+++ b/apps/test-app-runtime/package.json
@@ -28,7 +28,7 @@
     "@types/node": "^18",
     "aws-embedded-metrics": "^4.1.0",
     "jest": "^29",
-    "ts-jest": "^29",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"
   },

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -25,7 +25,7 @@
     "esbuild": "^0.17.4",
     "jest": "^29",
     "test-app-runtime": "workspace:^",
-    "ts-jest": "^29",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"
   },

--- a/apps/tests/aws-runtime-cdk/package.json
+++ b/apps/tests/aws-runtime-cdk/package.json
@@ -22,7 +22,7 @@
     "esbuild": "^0.17.4",
     "jest": "^29",
     "tests-runtime": "workspace:^",
-    "ts-jest": "^29",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"
   },

--- a/apps/tests/aws-runtime/package.json
+++ b/apps/tests/aws-runtime/package.json
@@ -34,7 +34,7 @@
     "jest": "^29",
     "node-fetch": "^3.3.0",
     "openapi3-ts": "^3",
-    "ts-jest": "^29",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"
   },

--- a/apps/tests/aws-runtime/test/tester.test.ts
+++ b/apps/tests/aws-runtime/test/tester.test.ts
@@ -120,11 +120,52 @@ eventualRuntimeTestHarness(
     testCompletion("awsSdkCalls", createAndDestroyWorkflow, "done");
 
     testCompletion("ent", entityWorkflow, [
+      [
+        [
+          {
+            namespace: "another",
+            n: 1000,
+          },
+          {
+            namespace: "default",
+            n: 6,
+          },
+          {
+            namespace: "different",
+            n: 1,
+          },
+        ],
+        [
+          {
+            namespace: "different",
+            n: 1,
+          },
+          {
+            namespace: "default",
+            n: 6,
+          },
+          {
+            namespace: "another",
+            n: 1000,
+          },
+        ],
+        [
+          {
+            namespace: "another",
+            n: 1000,
+          },
+        ],
+      ],
       { n: 7 },
       [
         [1, 1],
         [2, 2],
         [3, 1],
+      ],
+      [
+        [1, 1],
+        [3, 1],
+        [2, 2],
       ],
     ]);
 

--- a/apps/tests/aws-runtime/test/tester.test.ts
+++ b/apps/tests/aws-runtime/test/tester.test.ts
@@ -121,7 +121,11 @@ eventualRuntimeTestHarness(
 
     testCompletion("ent", entityWorkflow, [
       [
-        [
+        expect.arrayContaining([
+          {
+            namespace: "different",
+            n: 1,
+          },
           {
             namespace: "another",
             n: 1000,
@@ -130,11 +134,7 @@ eventualRuntimeTestHarness(
             namespace: "default",
             n: 6,
           },
-          {
-            namespace: "different",
-            n: 1,
-          },
-        ],
+        ]),
         [
           {
             namespace: "different",
@@ -163,8 +163,8 @@ eventualRuntimeTestHarness(
         [3, 1],
       ],
       [
-        [1, 1],
         [3, 1],
+        [1, 1],
         [2, 2],
       ],
     ]);

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lerna": "^6.6.2",
     "lint-staged": "^13.0.3",
     "prettier": "^2.8.8",
-    "ts-jest": "^29.0.3",
+    "ts-jest": "^29.1.0",
     "turbo": "^1.6.3",
     "typescript": "^5"
   },

--- a/packages/@eventual/aws-cdk/package.json
+++ b/packages/@eventual/aws-cdk/package.json
@@ -34,7 +34,7 @@
     "esbuild": "^0.17.4",
     "jest": "^29",
     "openapi3-ts": "^3.1.2",
-    "ts-jest": "^29",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5"
   },

--- a/packages/@eventual/aws-runtime/package.json
+++ b/packages/@eventual/aws-runtime/package.json
@@ -37,7 +37,7 @@
     "@types/jest": "^29",
     "@types/node": "^18",
     "jest": "^29",
-    "ts-jest": "^29",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5"
   },

--- a/packages/@eventual/aws-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/aws-runtime/src/stores/entity-store.ts
@@ -25,6 +25,7 @@ import {
   TransactionCancelled,
   TransactionConflict,
   UnexpectedVersion,
+  EntityIndex,
 } from "@eventual/core";
 import {
   EntityProvider,
@@ -170,7 +171,7 @@ export class AWSEntityStore extends EntityStore {
   }
 
   protected override async _query(
-    entity: Entity,
+    entity: Entity | EntityIndex,
     queryKey: NormalizedEntityCompositeKey<NormalizedEntityKeyCompletePart>,
     options?: EntityQueryOptions
   ): Promise<EntityQueryResult> {
@@ -194,6 +195,7 @@ export class AWSEntityStore extends EntityStore {
       },
       {
         TableName: this.tableName(entity),
+        IndexName: entity.kind === "EntityIndex" ? entity.name : undefined,
         KeyConditionExpression:
           queryKey.sort && queryKey.sort.keyValue !== undefined
             ? queryKey.sort.partialValue
@@ -379,8 +381,11 @@ export class AWSEntityStore extends EntityStore {
     return marshalledKey;
   }
 
-  private tableName(entity: Entity) {
-    return entityServiceTableName(getLazy(this.props.serviceName), entity.name);
+  private tableName(entity: Entity | EntityIndex) {
+    return entityServiceTableName(
+      getLazy(this.props.serviceName),
+      entity.kind === "EntityIndex" ? entity.entityName : entity.name
+    );
   }
 }
 

--- a/packages/@eventual/cli/package.json
+++ b/packages/@eventual/cli/package.json
@@ -21,7 +21,7 @@
     "@types/serve-static": "^1.15.0",
     "@types/yargs": "^17.0.13",
     "jest": "^29",
-    "ts-jest": "^29",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5"
   },

--- a/packages/@eventual/cli/src/display/event.ts
+++ b/packages/@eventual/cli/src/display/event.ts
@@ -80,7 +80,13 @@ function displayEntityCommand(operation: EntityOperation) {
         output.push(`Expected Version: ${options.expectedVersion}`);
       }
     }
-    if (isEntityOperationOfType("query", operation)) {
+    if (
+      isEntityOperationOfType("query", operation) ||
+      isEntityOperationOfType("queryIndex", operation)
+    ) {
+      if (isEntityOperationOfType("queryIndex", operation)) {
+        output.push(`Index: ${operation.indexName}`);
+      }
       const [key] = operation.params;
       output.push(`Key: ${JSON.stringify(key)}`);
     }

--- a/packages/@eventual/compiler/package.json
+++ b/packages/@eventual/compiler/package.json
@@ -44,7 +44,7 @@
     "@types/node": "^18",
     "esbuild": "^0.17.4",
     "jest": "^29",
-    "ts-jest": "^29",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5"
   },

--- a/packages/@eventual/core-runtime/package.json
+++ b/packages/@eventual/core-runtime/package.json
@@ -27,7 +27,7 @@
     "@types/jest": "^29",
     "@types/node": "^18",
     "jest": "^29",
-    "ts-jest": "^29",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5"
   },

--- a/packages/@eventual/core-runtime/src/workflow-call-executor.ts
+++ b/packages/@eventual/core-runtime/src/workflow-call-executor.ts
@@ -311,6 +311,12 @@ export class WorkflowCallExecutor {
     async function invokeEntityOperation(operation: EntityOperation) {
       if (isEntityOperationOfType("transact", operation)) {
         return self.props.entityStore.transactWrite(operation.items);
+      } else if (isEntityOperationOfType("queryIndex", operation)) {
+        return self.props.entityStore.queryIndex(
+          operation.entityName,
+          operation.indexName,
+          ...operation.params
+        );
       }
       return self.props.entityStore[operation.operation](
         operation.entityName,

--- a/packages/@eventual/core/package.json
+++ b/packages/@eventual/core/package.json
@@ -32,7 +32,7 @@
     "@types/jest": "^29",
     "@types/node": "^18",
     "jest": "^29",
-    "ts-jest": "^29",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5",
     "ulidx": "^0.3.0"

--- a/packages/@eventual/core/src/entity/entity.ts
+++ b/packages/@eventual/core/src/entity/entity.ts
@@ -333,8 +333,17 @@ export function entity<
         sort: indexOptions.sort,
         entityName: name,
         query: (...args) => {
-          return getEventualCallHook().registerEventualCall(undefined, () =>
-            getEntityHook().queryIndex(name, indexName, ...args)
+          return getEventualCallHook().registerEventualCall(
+            createEventualCall<EntityCall<"queryIndex">>(
+              EventualCallKind.EntityCall,
+              {
+                entityName: name,
+                indexName,
+                operation: "queryIndex",
+                params: args,
+              }
+            ),
+            () => getEntityHook().queryIndex(name, indexName, ...args)
           );
         },
       };

--- a/packages/@eventual/core/src/internal/calls.ts
+++ b/packages/@eventual/core/src/internal/calls.ts
@@ -1,6 +1,10 @@
 import type { Bucket } from "../bucket.js";
 import type { ConditionPredicate } from "../condition.js";
-import type { Entity, EntityTransactItem } from "../entity/entity.js";
+import type {
+  Entity,
+  EntityIndex,
+  EntityTransactItem,
+} from "../entity/entity.js";
 import type { EventEnvelope } from "../event.js";
 import type { DurationSchedule, Schedule } from "../schedule.js";
 import type { WorkflowExecutionOptions } from "../workflow.js";
@@ -107,16 +111,29 @@ export function isEntityOperationOfType<
 }
 
 export type EntityOperation<
-  Op extends EntityMethod | EntityTransactOperation["operation"] =
+  Op extends
     | EntityMethod
     | EntityTransactOperation["operation"]
+    | EntityQueryIndexOperation["operation"] =
+    | EntityMethod
+    | EntityTransactOperation["operation"]
+    | EntityQueryIndexOperation["operation"]
 > = Op extends EntityMethod
   ? {
       operation: Op;
       entityName: string;
       params: Parameters<Entity[Op]>;
     }
-  : EntityTransactOperation;
+  : Op extends "transact"
+  ? EntityTransactOperation
+  : EntityQueryIndexOperation;
+
+export interface EntityQueryIndexOperation {
+  operation: "queryIndex";
+  entityName: string;
+  indexName: string;
+  params: Parameters<EntityIndex["query"]>;
+}
 
 export interface EntityTransactOperation {
   operation: "transact";

--- a/packages/@eventual/core/src/internal/entity-hook.ts
+++ b/packages/@eventual/core/src/internal/entity-hook.ts
@@ -1,4 +1,10 @@
-import type { Entity, EntityTransactItem } from "../entity/entity.js";
+import type {
+  Entity,
+  EntityQueryOptions,
+  EntityQueryResult,
+  EntityTransactItem,
+} from "../entity/entity.js";
+import { QueryKey } from "../entity/key.js";
 
 declare global {
   // eslint-disable-next-line no-var
@@ -9,7 +15,7 @@ export type EntityMethod = Exclude<
   {
     [k in keyof Entity]: [Entity[k]] extends [Function] ? k : never;
   }[keyof Entity],
-  "partition" | "sort" | "stream" | undefined
+  "partition" | "sort" | "stream" | "index" | undefined
 >;
 
 /**
@@ -23,6 +29,12 @@ export type EntityHook = {
     ...args: Parameters<Entity[K]>
   ) => ReturnType<Entity[K]>;
 } & {
+  queryIndex(
+    entityName: string,
+    indexName: string,
+    queryKey: QueryKey,
+    options?: EntityQueryOptions
+  ): Promise<EntityQueryResult>;
   transactWrite(items: EntityTransactItem[]): Promise<void>;
 };
 

--- a/packages/@eventual/core/src/internal/service-spec.ts
+++ b/packages/@eventual/core/src/internal/service-spec.ts
@@ -172,6 +172,7 @@ export interface EntitySpec {
    */
   attributes: openapi.SchemaObject;
   streams: EntityStreamSpec[];
+  indices: EntityIndexSpec[];
 }
 
 export type EntityStreamOperation = "insert" | "modify" | "remove";
@@ -210,6 +211,14 @@ export interface EntityStreamSpec<
   entityName: string;
   options?: EntityStreamOptions<Attr, Partition, Sort>;
   sourceLocation?: SourceLocation;
+}
+
+export interface EntityIndexSpec {
+  name: string;
+  entityName: string;
+  key: KeyDefinition;
+  partition?: CompositeKeyPart<any>;
+  sort?: CompositeKeyPart<any>;
 }
 
 export interface TransactionSpec {

--- a/packages/@eventual/integrations-slack/package.json
+++ b/packages/@eventual/integrations-slack/package.json
@@ -29,7 +29,7 @@
     "@types/tsscmp": "^1.0.0",
     "itty-router": "2.6.6",
     "jest": "^29",
-    "ts-jest": "^29",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5",
     "ulidx": "^0.3.0"

--- a/packages/@eventual/testing/package.json
+++ b/packages/@eventual/testing/package.json
@@ -24,7 +24,7 @@
     "@types/jest": "^29",
     "@types/node": "^18",
     "jest": "^29",
-    "ts-jest": "^29",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5",
     "zod": "^3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: ^2.8.8
         version: 2.8.8
       ts-jest:
-        specifier: ^29.0.3
-        version: 29.0.5(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
+        specifier: ^29.1.0
+        version: 29.1.0(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
       turbo:
         specifier: ^1.6.3
         version: 1.7.4
@@ -96,8 +96,8 @@ importers:
         specifier: workspace:^
         version: link:../test-app-runtime
       ts-jest:
-        specifier: ^29
-        version: 29.0.5(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
+        specifier: ^29.1.0
+        version: 29.1.0(@babel/core@7.20.12)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@swc/core@1.3.35)(@types/node@18.13.0)(typescript@5.0.4)
@@ -160,8 +160,8 @@ importers:
         specifier: ^29
         version: 29.4.2(@types/node@18.13.0)(ts-node@10.9.1)
       ts-jest:
-        specifier: ^29
-        version: 29.0.5(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
+        specifier: ^29.1.0
+        version: 29.1.0(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@swc/core@1.3.35)(@types/node@18.13.0)(typescript@5.0.4)
@@ -277,8 +277,8 @@ importers:
         specifier: ^3
         version: 3.1.2
       ts-jest:
-        specifier: ^29
-        version: 29.0.5(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
+        specifier: ^29.1.0
+        version: 29.1.0(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@swc/core@1.3.35)(@types/node@18.13.0)(typescript@5.0.4)
@@ -326,8 +326,8 @@ importers:
         specifier: workspace:^
         version: link:../aws-runtime
       ts-jest:
-        specifier: ^29
-        version: 29.0.5(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
+        specifier: ^29.1.0
+        version: 29.1.0(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@swc/core@1.3.35)(@types/node@18.13.0)(typescript@5.0.4)
@@ -390,8 +390,8 @@ importers:
         specifier: ^3.1.2
         version: 3.1.2
       ts-jest:
-        specifier: ^29
-        version: 29.0.5(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
+        specifier: ^29.1.0
+        version: 29.1.0(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@swc/core@1.3.35)(@types/node@18.13.0)(typescript@5.0.4)
@@ -512,8 +512,8 @@ importers:
         specifier: ^29
         version: 29.4.2(@types/node@18.13.0)(ts-node@10.9.1)
       ts-jest:
-        specifier: ^29
-        version: 29.0.5(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
+        specifier: ^29.1.0
+        version: 29.1.0(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@swc/core@1.3.35)(@types/node@18.13.0)(typescript@5.0.4)
@@ -624,8 +624,8 @@ importers:
         specifier: ^29
         version: 29.4.2(@types/node@18.13.0)(ts-node@10.9.1)
       ts-jest:
-        specifier: ^29
-        version: 29.0.5(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
+        specifier: ^29.1.0
+        version: 29.1.0(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
       typescript:
         specifier: ^5
         version: 5.0.4
@@ -686,8 +686,8 @@ importers:
         specifier: ^29
         version: 29.4.2(@types/node@18.13.0)(ts-node@10.9.1)
       ts-jest:
-        specifier: ^29
-        version: 29.0.5(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
+        specifier: ^29.1.0
+        version: 29.1.0(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@swc/core@1.3.35)(@types/node@18.13.0)(typescript@5.0.4)
@@ -726,8 +726,8 @@ importers:
         specifier: ^29
         version: 29.4.2(@types/node@18.13.0)(ts-node@10.9.1)
       ts-jest:
-        specifier: ^29
-        version: 29.0.5(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
+        specifier: ^29.1.0
+        version: 29.1.0(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@swc/core@1.3.35)(@types/node@18.13.0)(typescript@5.0.4)
@@ -766,8 +766,8 @@ importers:
         specifier: ^29
         version: 29.4.2(@types/node@18.13.0)(ts-node@10.9.1)
       ts-jest:
-        specifier: ^29
-        version: 29.0.5(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
+        specifier: ^29.1.0
+        version: 29.1.0(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@swc/core@1.3.35)(@types/node@18.13.0)(typescript@5.0.4)
@@ -809,8 +809,8 @@ importers:
         specifier: ^29
         version: 29.4.2(@types/node@18.13.0)(ts-node@10.9.1)
       ts-jest:
-        specifier: ^29
-        version: 29.0.5(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
+        specifier: ^29.1.0
+        version: 29.1.0(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@swc/core@1.3.35)(@types/node@18.13.0)(typescript@5.0.4)
@@ -862,8 +862,8 @@ importers:
         specifier: ^29
         version: 29.4.2(@types/node@18.13.0)(ts-node@10.9.1)
       ts-jest:
-        specifier: ^29
-        version: 29.0.5(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
+        specifier: ^29.1.0
+        version: 29.1.0(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@swc/core@1.3.35)(@types/node@18.13.0)(typescript@5.0.4)
@@ -4907,7 +4907,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/fake-timers': 29.4.1
-      '@jest/types': 29.4.1
+      '@jest/types': 29.3.1
       '@types/node': 18.13.0
       jest-mock: 29.4.1
     dev: true
@@ -4954,12 +4954,12 @@ packages:
     resolution: {integrity: sha512-/1joI6rfHFmmm39JxNfmNAO3Nwm6Y0VoL5fJDy7H1AtWrD1CgRtqJbN9Ld6rhAkGO76qqp4cwhhxJ9o9kYjQMw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.4.2
+      '@jest/types': 29.5.0
       '@sinonjs/fake-timers': 10.0.2
       '@types/node': 18.13.0
       jest-message-util: 29.4.2
       jest-mock: 29.4.1
-      jest-util: 29.4.2
+      jest-util: 29.5.0
     dev: true
 
   /@jest/fake-timers@29.4.2:
@@ -4971,7 +4971,7 @@ packages:
       '@types/node': 18.13.0
       jest-message-util: 29.4.2
       jest-mock: 29.4.2
-      jest-util: 29.4.2
+      jest-util: 29.5.0
     dev: true
 
   /@jest/globals@29.3.1:
@@ -5120,19 +5120,7 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
       '@types/node': 18.13.0
-      '@types/yargs': 17.0.17
-      chalk: 4.1.2
-    dev: true
-
-  /@jest/types@29.4.1:
-    resolution: {integrity: sha512-zbrAXDUOnpJ+FMST2rV7QZOgec8rskg2zv8g2ajeqitp4tvZiyqTCYXANrKsM+ryj5o+LI+ZN2EgU9drrkiwSA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/schemas': 29.4.3
-      '@types/istanbul-lib-coverage': 2.0.4
-      '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.13.0
-      '@types/yargs': 17.0.20
+      '@types/yargs': 17.0.24
       chalk: 4.1.2
     dev: true
 
@@ -5145,6 +5133,18 @@ packages:
       '@types/istanbul-reports': 3.0.1
       '@types/node': 18.13.0
       '@types/yargs': 17.0.22
+      chalk: 4.1.2
+    dev: true
+
+  /@jest/types@29.5.0:
+    resolution: {integrity: sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.4.3
+      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-reports': 3.0.1
+      '@types/node': 18.13.0
+      '@types/yargs': 17.0.24
       chalk: 4.1.2
     dev: true
 
@@ -6224,8 +6224,8 @@ packages:
   /@tsconfig/node14@1.0.3:
     resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
 
-  /@tsconfig/node16@1.0.3:
-    resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
   /@tsconfig/node18@1.0.1:
     resolution: {integrity: sha512-sNFeK6X2ATlhlvzyH4kKYQlfHXE2f2/wxtB9ClvYXevWpmwkUT7VaSrjIN9E76Qebz8qP5JOJJ9jD3QoD/Z9TA==}
@@ -6494,20 +6494,14 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@types/yargs@17.0.17:
-    resolution: {integrity: sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==}
-    dependencies:
-      '@types/yargs-parser': 21.0.0
-    dev: true
-
-  /@types/yargs@17.0.20:
-    resolution: {integrity: sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==}
-    dependencies:
-      '@types/yargs-parser': 21.0.0
-    dev: true
-
   /@types/yargs@17.0.22:
     resolution: {integrity: sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==}
+    dependencies:
+      '@types/yargs-parser': 21.0.0
+    dev: true
+
+  /@types/yargs@17.0.24:
+    resolution: {integrity: sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==}
     dependencies:
       '@types/yargs-parser': 21.0.0
     dev: true
@@ -6607,7 +6601,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.0
+      semver: 7.5.1
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -6628,7 +6622,7 @@ packages:
       eslint: 8.40.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.40.0)
-      semver: 7.5.0
+      semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9202,7 +9196,7 @@ packages:
       is-core-module: 2.12.0
       minimatch: 3.1.2
       resolve: 1.22.2
-      semver: 7.5.0
+      semver: 7.5.1
     dev: true
 
   /eslint-plugin-node@11.1.0(eslint@8.40.0):
@@ -11035,7 +11029,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/code-frame': 7.21.4
-      '@jest/types': 29.4.2
+      '@jest/types': 29.5.0
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
       graceful-fs: 4.2.11
@@ -11049,18 +11043,18 @@ packages:
     resolution: {integrity: sha512-H8/qFDtDVMFvFP4X8NuOT3XRDzOUTz+FeACjufHzsOIBAxivLqkB1PoLCaJx9iPPQ8dZThHPp/G3WRWyMgA3JA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.4.1
+      '@jest/types': 29.3.1
       '@types/node': 18.13.0
-      jest-util: 29.4.1
+      jest-util: 29.5.0
     dev: true
 
   /jest-mock@29.4.1:
     resolution: {integrity: sha512-MwA4hQ7zBOcgVCVnsM8TzaFLVUD/pFWTfbkY953Y81L5ret3GFRZtmPmRFAjKQSdCKoJvvqOu6Bvfpqlwwb0dQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.4.2
+      '@jest/types': 29.5.0
       '@types/node': 18.13.0
-      jest-util: 29.4.2
+      jest-util: 29.5.0
     dev: true
 
   /jest-mock@29.4.2:
@@ -11069,7 +11063,7 @@ packages:
     dependencies:
       '@jest/types': 29.4.2
       '@types/node': 18.13.0
-      jest-util: 29.4.2
+      jest-util: 29.5.0
     dev: true
 
   /jest-pnp-resolver@1.2.3(jest-resolve@29.4.2):
@@ -11167,7 +11161,7 @@ packages:
       jest-resolve: 29.4.2
       jest-snapshot: 29.4.2
       jest-util: 29.4.2
-      semver: 7.5.0
+      semver: 7.5.1
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
@@ -11201,16 +11195,16 @@ packages:
       jest-util: 29.4.2
       natural-compare: 1.4.0
       pretty-format: 29.5.0
-      semver: 7.5.0
+      semver: 7.5.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /jest-util@29.4.1:
-    resolution: {integrity: sha512-bQy9FPGxVutgpN4VRc0hk6w7Hx/m6L53QxpDreTZgJd9gfx/AV2MjyPde9tGyZRINAUrSv57p2inGBu2dRLmkQ==}
+  /jest-util@29.4.2:
+    resolution: {integrity: sha512-wKnm6XpJgzMUSRFB7YF48CuwdzuDIHenVuoIb1PLuJ6F+uErZsuDkU+EiExkChf6473XcawBrSfDSnXl+/YG4g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.4.2
+      '@jest/types': 29.5.0
       '@types/node': 18.13.0
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -11218,11 +11212,11 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /jest-util@29.4.2:
-    resolution: {integrity: sha512-wKnm6XpJgzMUSRFB7YF48CuwdzuDIHenVuoIb1PLuJ6F+uErZsuDkU+EiExkChf6473XcawBrSfDSnXl+/YG4g==}
+  /jest-util@29.5.0:
+    resolution: {integrity: sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.4.2
+      '@jest/types': 29.5.0
       '@types/node': 18.13.0
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -11403,7 +11397,7 @@ packages:
       jws: 3.2.2
       lodash: 4.17.21
       ms: 2.1.3
-      semver: 7.5.0
+      semver: 7.5.1
     dev: false
 
   /jsx-ast-utils@3.3.3:
@@ -12670,7 +12664,7 @@ packages:
       '@yarnpkg/parsers': 3.0.0-rc.43
       '@zkochan/js-yaml': 0.0.6
       axios: 1.4.0
-      chalk: 4.1.2
+      chalk: 4.1.0
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
       cliui: 7.0.4
@@ -13926,6 +13920,14 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
+
+  /semver@7.5.1:
+    resolution: {integrity: sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
 
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
@@ -14563,8 +14565,8 @@ packages:
     resolution: {integrity: sha512-IrjjAwfM/J6ajWv5wDRZBdpVaTmuONJN1vC85mXlWVPXKelouLFiqsjR7m0h245qY6zZEtcDtcOTc4Rozgg1TQ==}
     engines: {node: '>=14'}
 
-  /ts-jest@29.0.5(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4):
-    resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
+  /ts-jest@29.1.0(@babel/core@7.20.12)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4):
+    resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
     peerDependencies:
@@ -14573,7 +14575,42 @@ packages:
       babel-jest: ^29.0.0
       esbuild: '*'
       jest: ^29.0.0
-      typescript: '>=4.3'
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.20.12
+      bs-logger: 0.2.6
+      esbuild: 0.17.8
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.4.2(@types/node@18.13.0)(ts-node@10.9.1)
+      jest-util: 29.5.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.5.1
+      typescript: 5.0.4
+      yargs-parser: 21.1.1
+    dev: true
+
+  /ts-jest@29.1.0(@babel/core@7.21.8)(esbuild@0.17.8)(jest@29.4.2)(typescript@5.0.4):
+    resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3 <6'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -14589,11 +14626,11 @@ packages:
       esbuild: 0.17.8
       fast-json-stable-stringify: 2.1.0
       jest: 29.4.2(@types/node@18.13.0)(ts-node@10.9.1)
-      jest-util: 29.4.2
+      jest-util: 29.5.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.3.8
+      semver: 7.5.1
       typescript: 5.0.4
       yargs-parser: 21.1.1
     dev: true
@@ -14617,7 +14654,7 @@ packages:
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
+      '@tsconfig/node16': 1.0.4
       '@types/node': 18.13.0
       acorn: 8.8.2
       acorn-walk: 8.2.0


### PR DESCRIPTION
Add index support for entities. Also upgraded ts-jest (they don't support semantic versioning and the latest version is the first that supports typescript 5).

```ts
const myEntity = entity("myEntity", {
    attributes: {
       pk: z.string(),
       pk2: z.string(),
       field1: z.number(),
       field2: z.number(),
    },
    partition: ["pk", "pk2"]
});

// create a GSI with pk as the only key part.
const index1 = myEntity.index("index1", {
    partition: ["pk1"]
});

// create a GSI with the original partition key [pk, pk2]
// NOTE: tables without a sort key cannot have LSIs
const index2 = myEntity.index("index2", {
    sort: ["field1"]
});

// create a GSI with the partition key [pk], ordered by field1
const index3 = myEntity.index("index3", {
    partition: ["pk1"],
    sort: ["field1"]
});



const myEntity = entity("myEntity", {
    attributes: {
       pk: z.string(),
       pk2: z.string(),
       field1: z.number(),
       field2: z.number(),
    },
    partition: ["pk", "pk2"],
    sort: ["field1"]
});

// create a GSI with pk as the only key part.
const index1 = myEntity.index("index1", {
    partition: ["pk1"]
});

// create a LSI with the original partition key [pk, pk2]
const index2 = myEntity.index("index2", {
    sort: ["field1"]
});

// create a GSI with the partition key [pk], ordered by field1
const index3 = myEntity.index("index3", {
    partition: ["pk1"],
    sort: ["field1"]
});
```