### PR TITLE
fix: support additional attribute types and fix zod object as attributes

### DIFF
--- a/packages/@eventual/core/src/entity/key.ts
+++ b/packages/@eventual/core/src/entity/key.ts
@@ -1,6 +1,6 @@
 import type { Attributes } from "./entity.js";
 
-export type KeyValue = string | number;
+export type KeyValue = string | number | bigint;
 
 /**
  * Composite Key - Whole key used to get and set an entity, made up of partition and sort key parts containing one or more attribute.

--- a/packages/@eventual/core/src/internal/entity.ts
+++ b/packages/@eventual/core/src/internal/entity.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
-import { Attributes, EntityZodShape } from "../entity/entity.js";
-import { CompositeKeyPart } from "../entity/key.js";
+import type { CompositeKeyPart } from "../entity/key.js";
 
 export interface KeyDefinitionPart {
   type: "number" | "string";
@@ -13,10 +12,10 @@ export interface KeyDefinition {
   sort?: KeyDefinitionPart;
 }
 
-export function computeKeyDefinition<Attr extends Attributes>(
-  attributes: z.ZodObject<EntityZodShape<Attr>>,
-  partition: CompositeKeyPart<Attr>,
-  sort?: CompositeKeyPart<Attr>
+export function computeKeyDefinition(
+  attributes: z.ZodObject<any>,
+  partition: CompositeKeyPart<any>,
+  sort?: CompositeKeyPart<any>
 ): KeyDefinition {
   const entityZodShape = attributes.shape;
 
@@ -26,7 +25,7 @@ export function computeKeyDefinition<Attr extends Attributes>(
   };
 
   function formatKeyDefinitionPart(
-    keyAttributes: CompositeKeyPart<Attr>
+    keyAttributes: CompositeKeyPart<any>
   ): KeyDefinitionPart {
     const [head, ...tail] = keyAttributes;
 

--- a/packages/@eventual/core/test/entity.test.ts
+++ b/packages/@eventual/core/test/entity.test.ts
@@ -1,0 +1,52 @@
+import { entity } from "../src/entity/index.js";
+import z from "zod";
+
+enum Enum {
+  A,
+  B = "B",
+}
+
+const testShape = {
+  string: z.string(),
+  opString: z.string().optional(),
+  enum: z.enum(["a", "b"]),
+  nativeEnum: z.nativeEnum(Enum),
+  boolean: z.boolean(),
+  number: z.number(),
+  null: z.null(),
+  array: z.array(z.string()),
+  obj: z.object({ a: z.string() }),
+  nested: z.object({ obj: z.object({ a: z.string() }) }),
+  tuple: z.tuple([z.string(), z.number()]),
+  set: z.set(z.string()),
+  any: z.any(),
+  bigint: z.bigint(),
+};
+
+/**
+ * Test that various forms of job attributes are accepted by the entity attributes.
+ *
+ * Note: the intention here is to test the types.
+ */
+test("entity attribute values", () => {
+  entity("aTestEntity1", {
+    attributes: testShape,
+    partition: ["any", "bigint", "enum", "nativeEnum", "number", "string"],
+    // @ts-expect-error
+    sort: ["blah", "set"],
+  });
+});
+
+/**
+ * Test that a z.object can be provided instead of a shape.
+ *
+ * Note: the intention here is to test the types.
+ */
+test("entity attribute from z.object", () => {
+  entity("aTestEntity2", {
+    attributes: z.object(testShape),
+    partition: ["any", "bigint", "enum", "nativeEnum", "number", "string"],
+    // @ts-expect-error
+    sort: ["blah", "set"],
+  });
+});


### PR DESCRIPTION
Entity did not support optional fields and z.object as attributes input caused compiler error.

See entity.tests.ts