### PR TITLE
feat: entity scan

### DIFF
--- a/packages/@eventual/core-runtime/src/local/stores/pagination.ts
+++ b/packages/@eventual/core-runtime/src/local/stores/pagination.ts
@@ -1,15 +1,15 @@
 export function paginateItems<Item>(
   items: Item[],
-  sort: (a: Item, b: Item) => number,
+  sort?: (a: Item, b: Item) => number,
   filter?: (item: Item) => boolean,
   direction?: "ASC" | "DESC",
   limit?: number,
   nextToken?: string
 ) {
   const tokenPayload = nextToken ? deserializeToken(nextToken) : undefined;
-  const sortedItems = items.sort((a, b) =>
-    direction === "DESC" ? -sort(a, b) : sort(a, b)
-  );
+  const sortedItems = sort
+    ? items.sort((a, b) => (direction === "DESC" ? -sort(a, b) : sort(a, b)))
+    : items;
   const filtered = filter ? sortedItems.filter(filter) : sortedItems;
   const start = tokenPayload?.index ?? 0;
   const rangeItems = filtered.slice(start, limit ? start + limit : undefined);

--- a/packages/@eventual/core-runtime/src/workflow-call-executor.ts
+++ b/packages/@eventual/core-runtime/src/workflow-call-executor.ts
@@ -1,6 +1,5 @@
 import type { ExecutionID, Workflow } from "@eventual/core";
 import {
-  assertNever,
   AwaitTimerCall,
   BucketCall,
   BucketGetObjectSerializedResult,
@@ -18,6 +17,17 @@ import {
   EventsEmitted,
   HistoryStateEvent,
   InvokeTransactionCall,
+  SendSignalCall,
+  SignalSent,
+  TaskCall,
+  TaskScheduled,
+  TimerCompleted,
+  TimerScheduled,
+  TransactionRequest,
+  TransactionRequestFailed,
+  TransactionRequestSucceeded,
+  WorkflowEventType,
+  assertNever,
   isAwaitTimerCall,
   isBucketCall,
   isBucketCallType,
@@ -32,16 +42,6 @@ import {
   isRegisterSignalHandlerCall,
   isSendSignalCall,
   isTaskCall,
-  SendSignalCall,
-  SignalSent,
-  TaskCall,
-  TaskScheduled,
-  TimerCompleted,
-  TimerScheduled,
-  TransactionRequest,
-  TransactionRequestFailed,
-  TransactionRequestSucceeded,
-  WorkflowEventType,
 } from "@eventual/core/internal";
 import stream from "stream";
 import type { EventClient } from "./clients/event-client.js";
@@ -313,6 +313,12 @@ export class WorkflowCallExecutor {
         return self.props.entityStore.transactWrite(operation.items);
       } else if (isEntityOperationOfType("queryIndex", operation)) {
         return self.props.entityStore.queryIndex(
+          operation.entityName,
+          operation.indexName,
+          ...operation.params
+        );
+      } else if (isEntityOperationOfType("scanIndex", operation)) {
+        return self.props.entityStore.scanIndex(
           operation.entityName,
           operation.indexName,
           ...operation.params

--- a/packages/@eventual/core/src/internal/calls.ts
+++ b/packages/@eventual/core/src/internal/calls.ts
@@ -114,10 +114,12 @@ export type EntityOperation<
   Op extends
     | EntityMethod
     | EntityTransactOperation["operation"]
-    | EntityQueryIndexOperation["operation"] =
+    | EntityQueryIndexOperation["operation"]
+    | EntityScanIndexOperation["operation"] =
     | EntityMethod
     | EntityTransactOperation["operation"]
     | EntityQueryIndexOperation["operation"]
+    | EntityScanIndexOperation["operation"]
 > = Op extends EntityMethod
   ? {
       operation: Op;
@@ -126,13 +128,22 @@ export type EntityOperation<
     }
   : Op extends "transact"
   ? EntityTransactOperation
-  : EntityQueryIndexOperation;
+  : Op extends "queryIndex"
+  ? EntityQueryIndexOperation
+  : EntityScanIndexOperation;
 
 export interface EntityQueryIndexOperation {
   operation: "queryIndex";
   entityName: string;
   indexName: string;
   params: Parameters<EntityIndex["query"]>;
+}
+
+export interface EntityScanIndexOperation {
+  operation: "scanIndex";
+  entityName: string;
+  indexName: string;
+  params: Parameters<EntityIndex["scan"]>;
 }
 
 export interface EntityTransactOperation {

--- a/packages/@eventual/core/src/internal/entity-hook.ts
+++ b/packages/@eventual/core/src/internal/entity-hook.ts
@@ -35,6 +35,11 @@ export type EntityHook = {
     queryKey: QueryKey,
     options?: EntityQueryOptions
   ): Promise<EntityQueryResult>;
+  scanIndex(
+    entityName: string,
+    indexName: string,
+    options?: EntityQueryOptions
+  ): Promise<EntityQueryResult>;
   transactWrite(items: EntityTransactItem[]): Promise<void>;
 };
 


### PR DESCRIPTION
* Adds `scan` to Entity and EntityIndex.
* Adds `consistentRead` to `get` `scan` and `query`.