### PR TITLE
fix: entity with sort fails to query without sort

### DIFF
--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -569,6 +569,11 @@ export const allCountersByN = counter.index("allCountersByN", {
   sort: ["n"],
 });
 
+export const countersByNamespace = counter.index("countersOrderedByNamespace", {
+  partition: ["id"],
+  sort: ["namespace"],
+});
+
 export const countersByN = counter.index("countersByN", {
   sort: ["n"],
 });
@@ -655,6 +660,12 @@ export const entityIndexTask = task(
         }))
       ),
       allCountersByN.query({ id }).then((q) =>
+        q.entries?.map((e) => ({
+          n: e.value.n,
+          namespace: e.value.namespace,
+        }))
+      ),
+      countersByNamespace.query({ id }).then((q) =>
         q.entries?.map((e) => ({
           n: e.value.n,
           namespace: e.value.namespace,

--- a/apps/tests/aws-runtime/test/tester.test.ts
+++ b/apps/tests/aws-runtime/test/tester.test.ts
@@ -154,6 +154,20 @@ eventualRuntimeTestHarness(
             namespace: "another",
             n: 1000,
           },
+          {
+            namespace: "default",
+            n: 6,
+          },
+          {
+            namespace: "different",
+            n: 1,
+          },
+        ],
+        [
+          {
+            namespace: "another",
+            n: 1000,
+          },
         ],
       ],
       { n: 7 },

--- a/packages/@eventual/aws-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/aws-runtime/src/stores/entity-store.ts
@@ -15,18 +15,18 @@ import {
 } from "@aws-sdk/client-dynamodb";
 import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
 import {
-  Entity,
   Attributes,
+  Entity,
   EntityConsistencyOptions,
+  EntityIndex,
   EntityQueryOptions,
   EntityQueryResult,
+  EntityReadOptions,
   EntitySetOptions,
   EntityWithMetadata,
   TransactionCancelled,
   TransactionConflict,
   UnexpectedVersion,
-  EntityIndex,
-  EntityReadOptions,
 } from "@eventual/core";
 import {
   EntityProvider,
@@ -204,7 +204,9 @@ export class AWSEntityStore extends EntityStore {
         IndexName: entity.kind === "EntityIndex" ? entity.name : undefined,
         ConsistentRead: options?.consistentRead,
         KeyConditionExpression:
-          queryKey.sort && queryKey.sort.keyValue !== undefined
+          queryKey.sort &&
+          (queryKey.sort.keyValue !== undefined ||
+            queryKey.sort.keyValue === "")
             ? queryKey.sort.partialValue
               ? `${formatAttributeNameMapKey(
                   queryKey.partition.keyAttribute
@@ -224,7 +226,9 @@ export class AWSEntityStore extends EntityStore {
             typeof queryKey.partition.keyValue === "number"
               ? { N: queryKey.partition.keyValue.toString() }
               : { S: queryKey.partition.keyValue },
-          ...(queryKey.sort && queryKey.sort.keyValue !== undefined
+          ...(queryKey.sort &&
+          (queryKey.sort.keyValue !== undefined ||
+            queryKey.sort.keyValue === "")
             ? {
                 ":sk":
                   typeof queryKey.sort.keyValue === "string"

--- a/packages/@eventual/core-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/core-runtime/src/stores/entity-store.ts
@@ -351,12 +351,17 @@ function formatNormalizedPart(
     attributes: keyPart.attributes,
     parts,
     keyAttribute: keyPart.keyAttribute,
-    keyValue: (keyPart.type === "number"
-      ? parts[0]?.value
-      : (missingValueIndex === -1 ? parts : parts.slice(0, missingValueIndex))
-          .map((p) => p.value)
-          .join("#")) as any,
-    partialValue: missingValueIndex !== -1,
+    keyValue:
+      // if there are no present values, return undefined
+      missingValueIndex === 0
+        ? undefined
+        : keyPart.type === "number"
+        ? parts[0]!.value
+        : (missingValueIndex === -1 ? parts : parts.slice(0, missingValueIndex))
+            .map((p) => p.value)
+            .join("#"),
+    // since true is more permissive (allows undefined), hack the types here to allow any value
+    partialValue: (missingValueIndex !== -1) as true,
   };
 }
 


### PR DESCRIPTION
When an Entity has a sort key and that key is a string, omitting the sort key from the query key fails. This is because the sort key is serialized to an empty string instead of undefined as expected and dynamo doesn't allow empty key values.

* Support empty string as a missing sort key when building the query.
* Treat any key key with no provided attributes (or a missing first key attribute) as undefined instead of an empty string.
* Add a test which has a string sort key (previous the sort keys in the tests were all numbers, which didn't have this issue)