### PR TITLE
chore: improve command output

### DIFF
--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -911,8 +911,8 @@ export const helloApi = command(
     path: "/hello",
     output: {
       schema: z.string(),
-      description: "201 output",
-      statusCode: 201,
+      description: "default output of hello command",
+      restStatusCode: 201,
     },
   },
   async () => {

--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -909,6 +909,11 @@ export const helloApi = command(
   "helloApi",
   {
     path: "/hello",
+    output: {
+      schema: z.string(),
+      description: "201 output",
+      statusCode: 201,
+    },
   },
   async () => {
     return "hello world";
@@ -1030,9 +1035,13 @@ export const modifyResponseMiddlewareHttp = api
     response.headers.set("ModifiedHeader", "Injected Header");
     return response;
   })
-  .get("/modify-response-http", async () => {
-    return new HttpResponse("My Response");
-  });
+  .get(
+    "/modify-response-http",
+    { description: "modify response middleware" },
+    async () => {
+      return new HttpResponse("My Response");
+    }
+  );
 
 export const contextTest = command("contextText", (_, { service }) => {
   return service;

--- a/packages/@eventual/compiler/src/eventual-infer.ts
+++ b/packages/@eventual/compiler/src/eventual-infer.ts
@@ -112,24 +112,20 @@ export function inferFromMemory(openApi: ServiceSpec["openApi"]): ServiceSpec {
           handlerTimeout: command.handlerTimeout,
           method: command.method as any,
           input: command.input ? generateSchema(command.input) : undefined,
-          outputs: [
-            ...(command.output
-              ? [
-                  {
-                    statusCode: command.output.statusCode,
-                    description: command.output.description,
-                    schema: command.output.schema
-                      ? generateSchema(command.output.schema)
-                      : undefined,
-                  },
-                ]
-              : []),
-            ...(command.otherOutputs?.map((o) => ({
-              statusCode: o.statusCode,
-              description: o.description,
-              schema: o.schema ? generateSchema(o.schema) : undefined,
-            })) ?? []),
-          ],
+          output: command.output
+            ? {
+                restStatusCode: command.output.restStatusCode,
+                description: command.output.description,
+                schema: command.output.schema
+                  ? generateSchema(command.output.schema)
+                  : undefined,
+              }
+            : undefined,
+          outputs: command.otherOutputs?.map((o) => ({
+            restStatusCode: o.restStatusCode,
+            description: o.description,
+            schema: o.schema ? generateSchema(o.schema) : undefined,
+          })),
           passThrough: command.passThrough,
           params: command.params as any,
           validate: command.validate,

--- a/packages/@eventual/compiler/src/eventual-infer.ts
+++ b/packages/@eventual/compiler/src/eventual-infer.ts
@@ -118,7 +118,7 @@ export function inferFromMemory(openApi: ServiceSpec["openApi"]): ServiceSpec {
                 description: command.output.description,
                 schema: command.output.schema
                   ? generateSchema(command.output.schema)
-                  : undefined,
+                  : { nullable: true },
               }
             : undefined,
           outputs: command.otherOutputs?.map((o) => ({

--- a/packages/@eventual/compiler/test/__snapshots__/infer-plugin.test.ts.snap
+++ b/packages/@eventual/compiler/test/__snapshots__/infer-plugin.test.ts.snap
@@ -507,7 +507,8 @@ function command(...args) {
     name,
     handler,
     sourceLocation,
-    ...options
+    ...options,
+    output: options?.output ? "restStatusCode" in options.output ? options.output : { schema: options.output, description: "OK", restStatusCode: 200 } : { schema: void 0, description: "OK", restStatusCode: 200 }
   };
   commands.push(command2);
   return command2;
@@ -552,6 +553,7 @@ function createRouter(middlewares) {
             args[2]
           ] : [void 0, args[0], void 0, args[1]];
           const command2 = {
+            description: routeProps?.description,
             kind: "Command",
             handler,
             memorySize: routeProps?.memorySize,
@@ -561,6 +563,7 @@ function createRouter(middlewares) {
             sourceLocation,
             handlerTimeout: routeProps?.handlerTimeout,
             middlewares,
+            otherOutputs: routeProps?.outputs,
             passThrough: true
           };
           commands.push(command2);

--- a/packages/@eventual/core-runtime/src/handlers/command-worker.ts
+++ b/packages/@eventual/core-runtime/src/handlers/command-worker.ts
@@ -121,9 +121,9 @@ function initRouter() {
           }
 
           let output: any = await command.handler(input, context);
-          if (command.output && shouldValidate) {
+          if (command.output?.schema && shouldValidate) {
             try {
-              output = command.output.parse(output);
+              output = command.output.schema.parse(output);
             } catch (err) {
               console.error("RPC output did not match schema", output, err);
               return new HttpResponse(JSON.stringify(err), {
@@ -133,7 +133,7 @@ function initRouter() {
             }
           }
           return new HttpResponse(JSON.stringify(output, jsonReplacer), {
-            status: 200,
+            status: command.output?.statusCode ?? 200,
           });
         })
       );
@@ -176,16 +176,16 @@ function initRouter() {
           // call the command RPC handler
           let output: any = await command.handler(input, context);
 
-          if (command.output && shouldValidate) {
+          if (command.output?.schema && shouldValidate) {
             // validate the output of the command handler against the schema if it's defined
-            output = command.output.parse(output);
+            output = command.output.schema.parse(output);
           }
 
           // TODO: support mapping RPC output back to HTTP properties such as Headers
           // TODO: support alternative status code https://github.com/functionless/eventual/issues/276
 
           return new HttpResponse(JSON.stringify(output, jsonReplacer), {
-            status: 200,
+            status: command.output?.statusCode ?? 200,
             headers: {
               "Content-Type": "application/json",
             },

--- a/packages/@eventual/core-runtime/src/handlers/command-worker.ts
+++ b/packages/@eventual/core-runtime/src/handlers/command-worker.ts
@@ -133,7 +133,7 @@ function initRouter() {
             }
           }
           return new HttpResponse(JSON.stringify(output, jsonReplacer), {
-            status: command.output?.statusCode ?? 200,
+            status: 200,
           });
         })
       );
@@ -185,7 +185,7 @@ function initRouter() {
           // TODO: support alternative status code https://github.com/functionless/eventual/issues/276
 
           return new HttpResponse(JSON.stringify(output, jsonReplacer), {
-            status: command.output?.statusCode ?? 200,
+            status: command.output?.restStatusCode ?? 200,
             headers: {
               "Content-Type": "application/json",
             },

--- a/packages/@eventual/core/src/http/command.ts
+++ b/packages/@eventual/core/src/http/command.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import type { z } from "zod";
 import type { FunctionRuntimeProps } from "../function-props.js";
 import type { HttpMethod } from "../http-method.js";
 import { commands } from "../internal/global.js";
@@ -163,7 +163,10 @@ export type CommandInput<C extends AnyCommand> = C extends Command<
   : never;
 
 export interface CommandOutputOptions<Output> {
-  schema: z.ZodType<Output>;
+  /**
+   * @default - {@link z.any}
+   */
+  schema?: z.ZodType<Output>;
   description: string;
   restStatusCode: number;
 }
@@ -236,10 +239,10 @@ export function command<
     sourceLocation,
     ...options,
     output: options?.output
-      ? options.output instanceof z.ZodType
-        ? { schema: options.output, description: "OK", restStatusCode: 200 }
-        : options.output
-      : { schema: z.any(), description: "OK", restStatusCode: 200 },
+      ? "restStatusCode" in options.output
+        ? options.output
+        : { schema: options.output, description: "OK", restStatusCode: 200 }
+      : { schema: undefined, description: "OK", restStatusCode: 200 },
   };
   commands.push(command);
   return command;

--- a/packages/@eventual/core/src/internal/open-api-spec.ts
+++ b/packages/@eventual/core/src/internal/open-api-spec.ts
@@ -89,17 +89,14 @@ export function generateOpenAPISpec(
               },
             },
           },
-          responses: command.outputs
-            ? Object.fromEntries(
-                command.outputs.map((o) => [
-                  o.statusCode,
-                  {
-                    content: { "application/json": { schema: o.schema } },
-                    description: o.description,
-                  } satisfies openapi.ResponseObject,
-                ])
-              )
-            : {},
+          responses: {
+            200: {
+              content: {
+                "application/json": { schema: command.output?.schema },
+              },
+              description: command.output?.description ?? "OK",
+            } satisfies openapi.ResponseObject,
+          },
         } satisfies openapi.OperationObject,
       };
 
@@ -197,17 +194,18 @@ export function generateOpenAPISpec(
               : {}),
           },
         },
-        responses: command.outputs
-          ? Object.fromEntries(
-              command.outputs.map((o) => [
-                o.statusCode,
-                {
-                  content: { "application/json": { schema: o.schema } },
-                  description: o.description,
-                } satisfies openapi.ResponseObject,
-              ])
-            )
-          : {},
+        responses: Object.fromEntries(
+          [
+            ...(command.output ? [command.output] : []),
+            ...(command.outputs ?? []),
+          ].map((o) => [
+            o.restStatusCode,
+            {
+              content: { "application/json": { schema: o.schema } },
+              description: o.description,
+            } satisfies openapi.ResponseObject,
+          ])
+        ),
       };
 
       return {

--- a/packages/@eventual/core/src/internal/open-api-spec.ts
+++ b/packages/@eventual/core/src/internal/open-api-spec.ts
@@ -89,12 +89,17 @@ export function generateOpenAPISpec(
               },
             },
           },
-          responses: {
-            default: {
-              content: { "application/json": { schema: command.output } },
-              description: `Default response for POST ${commandPath}`,
-            } satisfies openapi.ResponseObject,
-          },
+          responses: command.outputs
+            ? Object.fromEntries(
+                command.outputs.map((o) => [
+                  o.statusCode,
+                  {
+                    content: { "application/json": { schema: o.schema } },
+                    description: o.description,
+                  } satisfies openapi.ResponseObject,
+                ])
+              )
+            : {},
         } satisfies openapi.OperationObject,
       };
 
@@ -192,14 +197,17 @@ export function generateOpenAPISpec(
               : {}),
           },
         },
-        responses: {
-          default: {
-            description: `Default response for ${command.method} ${command.path}`,
-            content: {
-              "application/json": { schema: command.output },
-            },
-          },
-        },
+        responses: command.outputs
+          ? Object.fromEntries(
+              command.outputs.map((o) => [
+                o.statusCode,
+                {
+                  content: { "application/json": { schema: o.schema } },
+                  description: o.description,
+                } satisfies openapi.ResponseObject,
+              ])
+            )
+          : {},
       };
 
       return {

--- a/packages/@eventual/core/src/internal/service-spec.ts
+++ b/packages/@eventual/core/src/internal/service-spec.ts
@@ -82,7 +82,12 @@ export interface EventSpec {
 export interface CommandOutput {
   schema?: openapi.SchemaObject;
   description: string;
-  statusCode: number;
+  /**
+   * Status code of the output used in commands with a rest path.
+   *
+   * RPC commands always return a single 200 response.
+   */
+  restStatusCode: number;
 }
 
 export interface CommandSpec<
@@ -101,6 +106,21 @@ export interface CommandSpec<
    */
   summary?: string;
   input?: openapi.SchemaObject;
+  /**
+   * Output used by RPC commands and Rest commands to define the output of the handler.
+   *
+   * RPC will always have a status code of 200, but can override the default description of "OK".
+   *
+   * The REST command will return a 200 response unless an alternative is provided.
+   */
+  output?: CommandOutput;
+  /**
+   * Optional outputs provided by an http API command using passthrough mode.
+   *
+   * These commands return a {@link HttpResponse} which can define any number of outputs with custom status codes.
+   *
+   * The outputs are used to generate the {@link ApiSpecification}.
+   */
   outputs?: CommandOutput[];
   path?: Path;
   method?: Method;

--- a/packages/@eventual/core/src/internal/service-spec.ts
+++ b/packages/@eventual/core/src/internal/service-spec.ts
@@ -79,6 +79,12 @@ export interface EventSpec {
   schema?: openapi.SchemaObject;
 }
 
+export interface CommandOutput {
+  schema?: openapi.SchemaObject;
+  description: string;
+  statusCode: number;
+}
+
 export interface CommandSpec<
   Name extends string = string,
   Input = undefined,
@@ -95,7 +101,7 @@ export interface CommandSpec<
    */
   summary?: string;
   input?: openapi.SchemaObject;
-  output?: openapi.SchemaObject;
+  outputs?: CommandOutput[];
   path?: Path;
   method?: Method;
   params?: RestParams<Input, Path, Method>;


### PR DESCRIPTION
Improving the command output to API Specification.

1. outputs now default to a description of "OK". This description is required by openAPI, unfortunately.
2. allow overriding of the description from the service. Useful for things like openai plugins that may care about the description.
3. allow overriding of the status code for REST path commands. Reflected in the API Spec and the status code returned at runtime. 
    4. Would allow a command with a rest path to represent a 304 redirect or be labelled as 204 when no content is returned.
5. allow `api.[method]` commands (pass through) to specify an array of output schemas, descriptions, and status codes. 
6. default schema for RPC and REST commands (not pass through) is now `z.any` instead of undefined.
   7. in openapi, this is `{ nullable: true }`
8. allow api.[method] to provide a description for the command, pass through to the `ApiSpecification`.

```json
{
  "openapi": "3.0.1",
  "info": {
    "title": "eventual-tests",
    "version": "1"
  },
  "servers": [
    {
      "url": "https://ip98djye54.execute-api.us-east-1.amazonaws.com"
    }
  ],
  "paths": {
    "/hello3": {
      "post": {
        "operationId": "/hello3-POST",
        "parameters": [],
        "requestBody": {
          "content": {}
        },
        "responses": {}
      }
    },
    "/hello": {
      "get": {
        "operationId": "helloApi-get",
        "parameters": [],
        "requestBody": {
          "content": {}
        },
        "responses": {
          "201": {
            "content": {
              "application/json": {
                "schema": {
                  "type": "string"
                }
              }
            },
            "description": "default output of hello command"
          }
        }
      }
    },
    "/user/typed1/{userId}": {
      "get": {
        "operationId": "typed1-get",
        "parameters": [
          {
            "in": "path",
            "name": "userId",
            "schema": {
              "type": "string",
              "description": "The user ID to retrieve"
            }
          }
        ],
        "requestBody": {
          "content": {}
        },
        "responses": {
          "200": {
            "content": {
              "application/json": {
                "schema": {
                  "nullable": true
                }
              }
            },
            "description": "OK"
          }
        }
      }
    },
    "/user/typed2/{userId}": {
      "get": {
        "operationId": "typed2-GET",
        "parameters": [
          {
            "in": "query",
            "name": "detailed",
            "schema": {
              "type": "boolean"
            }
          },
          {
            "in": "path",
            "name": "userId",
            "schema": {
              "type": "string"
            }
          }
        ],
        "requestBody": {
          "content": {}
        },
        "responses": {
          "200": {
            "content": {
              "application/json": {
                "schema": {
                  "type": "object",
                  "properties": {
                    "userId": {
                      "type": "string"
                    },
                    "createdTime": {
                      "type": "string",
                      "format": "date-time",
                      "description": "Time the user was created"
                    }
                  },
                  "required": [
                    "userId",
                    "createdTime"
                  ]
                }
              }
            },
            "description": "OK"
          }
        }
      }
    },
    "/user/typedPut/{userId}": {
      "put": {
        "operationId": "typedPut-PUT",
        "description": "Update a user's info. Will write over whatever was set before.",
        "summary": "Update a user's info",
        "parameters": [
          {
            "in": "query",
            "name": "ExpectedVersion",
            "schema": {
              "type": "number"
            }
          },
          {
            "in": "path",
            "name": "userId",
            "schema": {
              "type": "string"
            }
          }
        ],
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {
                "type": "object",
                "properties": {
                  "age": {
                    "type": "number"
                  }
                },
                "required": [
                  "age"
                ]
              }
            }
          }
        },
        "responses": {
          "200": {
            "content": {
              "application/json": {
                "schema": {
                  "nullable": true
                }
              }
            },
            "description": "OK"
          }
        }
      }
    },
    "/early-middleware-response": {
      "get": {
        "operationId": "/early-middleware-response-GET",
        "parameters": [],
        "requestBody": {
          "content": {}
        },
        "responses": {}
      }
    },
    "/modify-response-http": {
      "get": {
        "operationId": "/modify-response-http-GET",
        "description": "modify response middleware",
        "parameters": [],
        "requestBody": {
          "content": {}
        },
        "responses": {}
      }
    }
  }
}
```