### PR TITLE
 fix: support sparse indicies

### DIFF
--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -575,11 +575,6 @@ export const countersByNamespace = counter.index("countersOrderedByNamespace", {
   sort: ["namespace"],
 });
 
-export const countersByOptional = counter.index("countersByOptional", {
-  partition: ["id"],
-  sort: ["optional"],
-});
-
 export const countersByOptional2 = counter.index("countersByOptional2", {
   partition: ["id"],
   sort: ["optional", "n"],
@@ -705,7 +700,7 @@ export const entityIndexTask = task(
         }))
       ),
       // sparse indices only include records with the given field
-      countersByOptional.query({ id }).then((q) =>
+      countersByOptional2.query({ id }).then((q) =>
         q.entries?.map((e) => ({
           n: e.value.n,
           namespace: e.value.namespace,

--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -577,7 +577,7 @@ export const countersByNamespace = counter.index("countersOrderedByNamespace", {
 
 export const countersByOptional = counter.index("countersByOptional", {
   partition: ["id"],
-  sort: ["optional"],
+  sort: ["optional", "n"],
 });
 
 export const countersByN = counter.index("countersByN", {

--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -575,7 +575,7 @@ export const countersByNamespace = counter.index("countersOrderedByNamespace", {
   sort: ["namespace"],
 });
 
-export const countersByOptional = counter.index("countersOrderedByNamespace", {
+export const countersByOptional = counter.index("countersByOptional", {
   partition: ["id"],
   sort: ["optional"],
 });

--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -556,6 +556,7 @@ export const counter = entity("counter5", {
       z.literal("another"),
     ]),
     id: z.string(),
+    optional: z.string().optional(),
   },
   partition: ["namespace", "id"],
 });
@@ -572,6 +573,11 @@ export const allCountersByN = counter.index("allCountersByN", {
 export const countersByNamespace = counter.index("countersOrderedByNamespace", {
   partition: ["id"],
   sort: ["namespace"],
+});
+
+export const countersByOptional = counter.index("countersOrderedByNamespace", {
+  partition: ["id"],
+  sort: ["optional"],
 });
 
 export const countersByN = counter.index("countersByN", {
@@ -623,6 +629,7 @@ export const counterNamespaceWatcher = counter.stream(
         namespace: "default",
         id: value!.id,
         n: (value?.n ?? 0) + 1,
+        optional: undefined,
       });
       console.log("send signal to", value!.id);
       await entitySignal.sendSignal(value!.id);
@@ -635,7 +642,12 @@ export const onEntityEvent = subscription(
   { events: [entityEvent] },
   async ({ id }) => {
     const value = await counter.get({ namespace: "default", id });
-    await counter.set({ namespace: "default", id, n: (value?.n ?? 0) + 1 });
+    await counter.set({
+      namespace: "default",
+      id,
+      n: (value?.n ?? 0) + 1,
+      optional: undefined,
+    });
     await entitySignal.sendSignal(id);
   }
 );
@@ -644,14 +656,24 @@ export const entityTask = task(
   "entityTask",
   async (_, { execution: { id } }) => {
     const value = await counter.get(["default", id]);
-    await counter.set({ namespace: "default", id, n: (value?.n ?? 0) + 1 });
+    await counter.set({
+      namespace: "default",
+      id,
+      n: (value?.n ?? 0) + 1,
+      optional: undefined,
+    });
   }
 );
 
 export const entityIndexTask = task(
   "entityIndexTask",
   async (_, { execution: { id } }) => {
-    await counter.set({ namespace: "another", id, n: 1000 });
+    await counter.set({
+      namespace: "another",
+      id,
+      n: 1000,
+      optional: "hello",
+    });
     return await Promise.all([
       allCounters.query({ id }).then((q) =>
         q.entries?.map((e) => ({
@@ -677,6 +699,13 @@ export const entityIndexTask = task(
           namespace: e.value.namespace,
         }))
       ),
+      // sparse indices only include records with the given field
+      countersByOptional.query({ id }).then((q) =>
+        q.entries?.map((e) => ({
+          n: e.value.n,
+          namespace: e.value.namespace,
+        }))
+      ),
     ]);
   }
 );
@@ -684,15 +713,20 @@ export const entityIndexTask = task(
 export const entityWorkflow = workflow(
   "entityWorkflow",
   async (_, { execution: { id } }) => {
-    await counter.set({ namespace: "default", id, n: 1 });
-    await counter.set({ namespace: "different", id, n: 1 });
+    await counter.set({ namespace: "default", id, n: 1, optional: undefined });
+    await counter.set({
+      namespace: "different",
+      id,
+      n: 1,
+      optional: undefined,
+    });
     await entitySignal.expectSignal();
     await entityTask();
     await Promise.all([entityEvent.emit({ id }), entitySignal.expectSignal()]);
     try {
       // will fail
       await counter.set(
-        { namespace: "default", id, n: 0 },
+        { namespace: "default", id, n: 0, optional: undefined },
         { expectedVersion: 1 }
       );
     } catch (err) {
@@ -701,7 +735,7 @@ export const entityWorkflow = workflow(
     const { value: entityValue, version } =
       (await counter.getWithMetadata(["default", id])) ?? {};
     await counter.set(
-      { namespace: "default", id, n: entityValue!.n + 1 },
+      { namespace: "default", id, n: entityValue!.n + 1, optional: undefined },
       { expectedVersion: version }
     );
     const value = await counter.get(["default", id]);

--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -575,7 +575,7 @@ export const countersByNamespace = counter.index("countersOrderedByNamespace", {
   sort: ["namespace"],
 });
 
-export const countersByOptional = counter.index("countersByOptional", {
+export const countersByOptional = counter.index("countersByOptional2", {
   partition: ["id"],
   sort: ["optional", "n"],
 });

--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -575,7 +575,12 @@ export const countersByNamespace = counter.index("countersOrderedByNamespace", {
   sort: ["namespace"],
 });
 
-export const countersByOptional = counter.index("countersByOptional2", {
+export const countersByOptional = counter.index("countersByOptional", {
+  partition: ["id"],
+  sort: ["optional"],
+});
+
+export const countersByOptional2 = counter.index("countersByOptional2", {
   partition: ["id"],
   sort: ["optional", "n"],
 });

--- a/apps/tests/aws-runtime/test/tester.test.ts
+++ b/apps/tests/aws-runtime/test/tester.test.ts
@@ -169,6 +169,12 @@ eventualRuntimeTestHarness(
             n: 1000,
           },
         ],
+        [
+          {
+            namespace: "another",
+            n: 1000,
+          },
+        ],
       ],
       { n: 7 },
       [

--- a/packages/@eventual/aws-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/aws-runtime/src/stores/entity-store.ts
@@ -39,7 +39,7 @@ import {
   NormalizedEntityKeyCompletePart,
   NormalizedEntityTransactItem,
   removeGeneratedKeyAttributes,
-  removeOriginalKeyAttributes,
+  removeKeyAttributes,
 } from "@eventual/core-runtime";
 import { assertNever } from "@eventual/core/internal";
 import {
@@ -382,9 +382,10 @@ export class AWSEntityStore extends EntityStore {
     );
 
     // remove the entity keys if they are not generated
-    const valueToSave = removeOriginalKeyAttributes(
+    const valueToSave = removeKeyAttributes(
       entity,
       { ...value, ...indexGeneratedAttributes },
+      undefined,
       true,
       true
     );

--- a/packages/@eventual/core-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/core-runtime/src/stores/entity-store.ts
@@ -424,36 +424,19 @@ export function removeGeneratedKeyAttributes(
 }
 
 /**
- * Removes any original key attributes found in the entity key or index keys.
- *
- * Original attributes may be re-used for single-attribute keys.
+ * Removes any key attributes found in the entity key or index keys.
  */
-export function removeOriginalKeyAttributes(
+export function removeKeyAttributes(
   entity: Entity,
   value: Attributes,
-  excludeIndices = false,
-  mutate = false
-): Attributes {
-  return removeKeyAttributes(
-    entity,
-    value,
-    (k) => k.attributes.length === 1,
-    excludeIndices,
-    mutate
-  );
-}
-
-function removeKeyAttributes(
-  entity: Entity,
-  value: Attributes,
-  filter: (part: KeyDefinitionPart) => boolean,
+  filter?: (part: KeyDefinitionPart) => boolean,
   excludeIndices = false,
   mutate = false
 ): Attributes {
   const keysToDelete = new Set(
     [entity.key, ...(excludeIndices ? [] : entity.indices.map((k) => k.key))]
       .flatMap((k) => (k.sort ? [k.partition, k.sort] : [k.partition]))
-      .filter(filter)
+      .filter((k) => (filter ? filter(k) : true))
       .map((k) => k.keyAttribute)
   );
 

--- a/packages/@eventual/core-runtime/src/utils.ts
+++ b/packages/@eventual/core-runtime/src/utils.ts
@@ -2,7 +2,7 @@ import type {
   BucketNotificationEvent,
   Entity,
   Attributes,
-  CompositeKeyPart,
+  EntityCompositeKeyPart,
   KeyTuple,
   EntityStreamItem,
 } from "@eventual/core";
@@ -72,9 +72,7 @@ export function serializeCompositeKey(
   return `${entityName}|${key.partition.keyValue}|${key.sort?.keyValue ?? ""}`;
 }
 
-export function deserializeCompositeKey(
-  sKey: string
-): [string, KeyTuple<any, any, any>] {
+export function deserializeCompositeKey(sKey: string): [string, KeyTuple] {
   const [name, partition, sort] = sKey.split("|") as [string, string, string];
   return [name, sort ? [partition, sort] : [partition]];
 }
@@ -91,8 +89,8 @@ export function isBucketNotificationEvent(
 
 export function entityStreamMatchesItem<
   Attr extends Attributes,
-  const Partition extends CompositeKeyPart<Attr>,
-  const Sort extends CompositeKeyPart<Attr> | undefined
+  const Partition extends EntityCompositeKeyPart<Attr>,
+  const Sort extends EntityCompositeKeyPart<Attr> | undefined
 >(
   entity: Entity<Attr, Partition, Sort>,
   item: EntityStreamItem<Attr, Partition, Sort>,

--- a/packages/@eventual/core-runtime/test/transaction-executor.test.ts
+++ b/packages/@eventual/core-runtime/test/transaction-executor.test.ts
@@ -1,6 +1,6 @@
 import {
   Attributes,
-  CompositeKeyPart,
+  EntityCompositeKeyPart,
   EntityOptions,
   TransactionContext,
   entity as _entity,
@@ -25,8 +25,8 @@ const entity = (() => {
   let n = 0;
   return <
     Attr extends Attributes,
-    const Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-    const Sort extends CompositeKeyPart<Attr> | undefined = undefined
+    const Partition extends EntityCompositeKeyPart<Attr> = EntityCompositeKeyPart<Attr>,
+    const Sort extends EntityCompositeKeyPart<Attr> | undefined = undefined
   >(
     options: EntityOptions<Attr, Partition, Sort>
   ) => {

--- a/packages/@eventual/core/src/entity/entity.ts
+++ b/packages/@eventual/core/src/entity/entity.ts
@@ -14,7 +14,12 @@ import {
   isSourceLocation,
   SourceLocation,
 } from "../internal/service-spec.js";
-import type { CompositeKey, CompositeKeyPart, QueryKey } from "./key.js";
+import type {
+  CompositeKey,
+  EntityCompositeKeyPart,
+  IndexCompositeKeyPart,
+  QueryKey,
+} from "./key.js";
 import type { EntityStream, EntityStreamHandler } from "./stream.js";
 
 export type AttributeBinaryValue =
@@ -68,9 +73,9 @@ export type EntityZodShape<Attr extends Attributes> = {
  */
 export interface Entity<
   Attr extends Attributes = any,
-  Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined =
-    | CompositeKeyPart<Attr>
+  Partition extends EntityCompositeKeyPart<Attr> = EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined =
+    | EntityCompositeKeyPart<Attr>
     | undefined
 > extends Omit<
     EntitySpec,
@@ -130,8 +135,10 @@ export interface Entity<
    */
   scan(request?: EntityQueryOptions): Promise<EntityQueryResult<Attr>>;
   index<
-    const IndexPartition extends CompositeKeyPart<Attr> | undefined = undefined,
-    const IndexSort extends CompositeKeyPart<Attr> | undefined = undefined
+    const IndexPartition extends
+      | IndexCompositeKeyPart<Attr>
+      | undefined = undefined,
+    const IndexSort extends IndexCompositeKeyPart<Attr> | undefined = undefined
   >(
     name: string,
     options: EntityIndexOptions<Attr, IndexPartition, IndexSort>
@@ -175,8 +182,8 @@ export type ZodAttributesObject<T extends Attributes> = z.ZodObject<
 
 export interface EntityOptions<
   Attr extends Attributes,
-  Partition extends CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined = undefined
+  Partition extends EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined = undefined
 > {
   attributes: ZodAttributesObject<Attr> | EntityZodShape<Attr>;
   partition: Partition;
@@ -246,8 +253,8 @@ export interface EntityOptions<
  */
 export function entity<
   Attr extends Attributes,
-  const Partition extends CompositeKeyPart<Attr>,
-  const Sort extends CompositeKeyPart<Attr> | undefined = undefined
+  const Partition extends EntityCompositeKeyPart<Attr>,
+  const Sort extends EntityCompositeKeyPart<Attr> | undefined = undefined
 >(
   name: string,
   options: EntityOptions<Attr, Partition, Sort>
@@ -466,8 +473,8 @@ export function entity<
 
 export type EntityIndexOptions<
   Attr extends Attributes,
-  Partition extends CompositeKeyPart<Attr> | undefined = undefined,
-  Sort extends CompositeKeyPart<Attr> | undefined = undefined
+  Partition extends IndexCompositeKeyPart<Attr> | undefined = undefined,
+  Sort extends IndexCompositeKeyPart<Attr> | undefined = undefined
 > =
   | {
       partition: Partition;
@@ -479,18 +486,18 @@ export type EntityIndexOptions<
 
 export type EntityIndexMapper<
   Attr extends Attributes,
-  EntityPartition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-  IndexPartition extends CompositeKeyPart<Attr> | undefined = undefined,
-  Sort extends CompositeKeyPart<Attr> | undefined = undefined
+  EntityPartition extends EntityCompositeKeyPart<Attr> = EntityCompositeKeyPart<Attr>,
+  IndexPartition extends IndexCompositeKeyPart<Attr> | undefined = undefined,
+  Sort extends IndexCompositeKeyPart<Attr> | undefined = undefined
 > = IndexPartition extends undefined
   ? EntityIndex<Attr, EntityPartition, Sort>
   : EntityIndex<Attr, Exclude<IndexPartition, undefined>, Sort>;
 
 export interface EntityIndex<
   Attr extends Attributes = any,
-  Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined =
-    | CompositeKeyPart<Attr>
+  Partition extends IndexCompositeKeyPart<Attr> = IndexCompositeKeyPart<Attr>,
+  Sort extends IndexCompositeKeyPart<Attr> | undefined =
+    | IndexCompositeKeyPart<Attr>
     | undefined
 > extends EntityIndexSpec {
   kind: "EntityIndex";
@@ -559,17 +566,17 @@ export interface EntityWithMetadata<Attr extends Attributes = Attributes> {
 
 interface EntityTransactItemBase<
   Attr extends Attributes,
-  Partition extends CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined
+  Partition extends EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined
 > {
   entity: Entity<Attr, Partition, Sort> | string;
 }
 
 export type EntityTransactItem<
   Attr extends Attributes = any,
-  Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined =
-    | CompositeKeyPart<Attr>
+  Partition extends EntityCompositeKeyPart<Attr> = EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined =
+    | EntityCompositeKeyPart<Attr>
     | undefined
 > =
   | EntityTransactSetOperation<Attr, Partition, Sort>
@@ -578,9 +585,9 @@ export type EntityTransactItem<
 
 export interface EntityTransactSetOperation<
   Attr extends Attributes = any,
-  Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined =
-    | CompositeKeyPart<Attr>
+  Partition extends EntityCompositeKeyPart<Attr> = EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined =
+    | EntityCompositeKeyPart<Attr>
     | undefined
 > extends EntityTransactItemBase<Attr, Partition, Sort> {
   operation: "set";
@@ -590,9 +597,9 @@ export interface EntityTransactSetOperation<
 
 export interface EntityTransactDeleteOperation<
   Attr extends Attributes = any,
-  Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined =
-    | CompositeKeyPart<Attr>
+  Partition extends EntityCompositeKeyPart<Attr> = EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined =
+    | EntityCompositeKeyPart<Attr>
     | undefined
 > extends EntityTransactItemBase<Attr, Partition, Sort> {
   operation: "delete";
@@ -605,9 +612,9 @@ export interface EntityTransactDeleteOperation<
  */
 export interface EntityTransactConditionalOperation<
   Attr extends Attributes = any,
-  Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined =
-    | CompositeKeyPart<Attr>
+  Partition extends EntityCompositeKeyPart<Attr> = EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined =
+    | EntityCompositeKeyPart<Attr>
     | undefined
 > extends EntityTransactItemBase<Attr, Partition, Sort> {
   operation: "condition";

--- a/packages/@eventual/core/src/entity/key.ts
+++ b/packages/@eventual/core/src/entity/key.ts
@@ -11,21 +11,45 @@ export type KeyValue = string | number | bigint;
 /**
  * Any attribute name considered to be a valid key attribute.
  */
-export type KeyAttribute<Attr extends Attributes> = {
+export type KeyAttribute<Attr extends Attributes, Values = KeyValue> = {
   [K in keyof Attr]: K extends string
     ? // only include attributes that extend string or number
-      Attr[K] extends KeyValue
+      Attr[K] extends Values
       ? K
       : never
     : never;
 }[keyof Attr];
 
 /**
- * A part of the composite key, either the partition or sort key.
+ * An at least one tuple of attribute keys. Attributes can refer to any {@link KeyValue}.
+ *
+ * Used to define a key in an Entity, where all key attributes must not be optional.
+ */
+export type EntityCompositeKeyPart<Attr extends Attributes> = readonly [
+  KeyAttribute<Attr, KeyValue>,
+  ...KeyAttribute<Attr, KeyValue>[]
+];
+
+/**
+ * An at least one tuple of attribute keys. Attributes can refer to any {@link KeyValue} and may be optional.
+ *
+ * Used to define a key in an {@link EntityIndex}, where key attributes may refer to optional fields. This is called a sparse index.
+ */
+export type IndexCompositeKeyPart<Attr extends Attributes> =
+  | readonly [
+      KeyAttribute<Attr, KeyValue | undefined>,
+      ...KeyAttribute<Attr, KeyValue | undefined>[]
+    ]
+  | EntityCompositeKeyPart<Attr>;
+
+/**
+ * An at least one tuple of attribute keys. Does not include attribute type constraints, but the keys must be string.
+ *
+ * Should match either {@link IndexCompositeKeyPart} or {@link EntityCompositeKeyPart}.
  */
 export type CompositeKeyPart<Attr extends Attributes> = readonly [
-  KeyAttribute<Attr>,
-  ...KeyAttribute<Attr>[]
+  KeyAttribute<Attr, any>,
+  ...KeyAttribute<Attr, any>[]
 ];
 
 /**
@@ -47,10 +71,10 @@ export type KeyMap<
     | CompositeKeyPart<Attr>
     | undefined
 > = {
-  [k in Partition[number]]: Attr[k];
+  [k in Partition[number]]: Exclude<Attr[k], undefined>;
 } & (Sort extends CompositeKeyPart<Attr>
   ? {
-      [k in Sort[number]]: Attr[k];
+      [k in Sort[number]]: Exclude<Attr[k], undefined>;
     }
   : // eslint-disable-next-line
     {});
@@ -64,7 +88,7 @@ export type KeyPartialTuple<
       infer Head extends keyof Attr,
       ...infer Rest extends readonly (keyof Attr)[]
     ]
-  ? readonly [Attr[Head], ...KeyPartialTuple<Attr, Rest>]
+  ? readonly [Extract<Attr[Head], KeyValue>, ...KeyPartialTuple<Attr, Rest>]
   : readonly [];
 
 /**
@@ -75,9 +99,11 @@ export type KeyPartialTuple<
  * ```
  */
 export type KeyTuple<
-  Attr extends Attributes,
-  Partition extends CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined
+  Attr extends Attributes = Attributes,
+  Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
+  Sort extends CompositeKeyPart<Attr> | undefined =
+    | CompositeKeyPart<Attr>
+    | undefined
 > = Sort extends undefined
   ? KeyPartialTuple<Attr, Partition>
   : readonly [
@@ -96,6 +122,21 @@ export type CompositeKey<
     | undefined
 > = KeyMap<Attr, Partition, Sort> | KeyTuple<Attr, Partition, Sort>;
 
+export type ProgressiveTupleQueryKey<
+  Attr extends Attributes,
+  Sort extends readonly (keyof Attr)[],
+  Accum extends [] = []
+> = Sort extends readonly []
+  ? Accum
+  : Sort extends readonly [
+      infer k extends keyof Attr,
+      ...infer ks extends readonly (keyof Attr)[]
+    ]
+  ?
+      | Accum
+      | ProgressiveQueryKey<Attr, ks, [...Accum, Extract<Attr[k], KeyValue>]>
+  : never;
+
 export type ProgressiveQueryKey<
   Attr extends Attributes,
   Sort extends readonly (keyof Attr)[],
@@ -112,7 +153,7 @@ export type ProgressiveQueryKey<
           Attr,
           ks,
           Accum & {
-            [sk in k]: Attr[sk];
+            [sk in k]: Extract<Attr[sk], KeyValue>;
           }
         >
   : never;
@@ -134,12 +175,17 @@ export type QueryKey<
     | undefined
 > =
   | ({
-      [pk in Partition[number]]: Attr[pk];
+      [pk in Partition[number]]: Extract<Attr[pk], KeyValue>;
     } & (Sort extends undefined
       ? // eslint-disable-next-line
         {}
       : ProgressiveQueryKey<Attr, Exclude<Sort, undefined>>))
-  | Partial<KeyTuple<Attr, Partition, Sort>>;
+  | [
+      ...KeyTuple<Attr, Partition>,
+      ...(Sort extends undefined
+        ? []
+        : ProgressiveTupleQueryKey<Attr, Exclude<Sort, undefined>>)
+    ];
 
 /**
  * A stream query can contain partial sort keys and partial partition keys.

--- a/packages/@eventual/core/src/entity/key.ts
+++ b/packages/@eventual/core/src/entity/key.ts
@@ -201,3 +201,13 @@ export type StreamQueryKey<
     ? // eslint-disable-next-line
       {}
     : ProgressiveQueryKey<Attr, Exclude<Sort, undefined>>);
+
+export type KeyAttributes<
+  Attr extends Attributes = any,
+  Partition extends IndexCompositeKeyPart<Attr> = IndexCompositeKeyPart<Attr>,
+  Sort extends IndexCompositeKeyPart<Attr> | undefined =
+    | IndexCompositeKeyPart<Attr>
+    | undefined
+> = Sort extends undefined
+  ? Partition[number]
+  : [...Partition, ...Exclude<Sort, undefined>][number];

--- a/packages/@eventual/core/src/entity/stream.ts
+++ b/packages/@eventual/core/src/entity/stream.ts
@@ -6,7 +6,7 @@ import {
 } from "../internal/service-spec.js";
 import type { ServiceContext } from "../service.js";
 import type { Entity, Attributes } from "./entity.js";
-import type { CompositeKeyPart, KeyMap } from "./key.js";
+import type { EntityCompositeKeyPart, KeyMap } from "./key.js";
 
 export interface EntityStreamContext {
   /**
@@ -17,9 +17,9 @@ export interface EntityStreamContext {
 
 export interface EntityStreamHandler<
   Attr extends Attributes = Attributes,
-  Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined =
-    | CompositeKeyPart<Attr>
+  Partition extends EntityCompositeKeyPart<Attr> = EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined =
+    | EntityCompositeKeyPart<Attr>
     | undefined
 > {
   /**
@@ -33,9 +33,9 @@ export interface EntityStreamHandler<
 
 export interface EntityStreamItemBase<
   Attr extends Attributes = Attributes,
-  Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined =
-    | CompositeKeyPart<Attr>
+  Partition extends EntityCompositeKeyPart<Attr> = EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined =
+    | EntityCompositeKeyPart<Attr>
     | undefined
 > {
   streamName: string;
@@ -45,9 +45,9 @@ export interface EntityStreamItemBase<
 
 export type EntityStreamItem<
   Attr extends Attributes = Attributes,
-  Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined =
-    | CompositeKeyPart<Attr>
+  Partition extends EntityCompositeKeyPart<Attr> = EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined =
+    | EntityCompositeKeyPart<Attr>
     | undefined
 > =
   | EntityStreamInsertItem<Attr, Partition, Sort>
@@ -56,9 +56,9 @@ export type EntityStreamItem<
 
 export interface EntityStreamInsertItem<
   Attr extends Attributes = Attributes,
-  Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined =
-    | CompositeKeyPart<Attr>
+  Partition extends EntityCompositeKeyPart<Attr> = EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined =
+    | EntityCompositeKeyPart<Attr>
     | undefined
 > extends EntityStreamItemBase<Attr, Partition, Sort> {
   newValue: Attr;
@@ -68,9 +68,9 @@ export interface EntityStreamInsertItem<
 
 export interface EntityStreamModifyItem<
   Attr extends Attributes = Attributes,
-  Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined =
-    | CompositeKeyPart<Attr>
+  Partition extends EntityCompositeKeyPart<Attr> = EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined =
+    | EntityCompositeKeyPart<Attr>
     | undefined
 > extends EntityStreamItemBase<Attr, Partition, Sort> {
   operation: "modify";
@@ -82,9 +82,9 @@ export interface EntityStreamModifyItem<
 
 export interface EntityStreamRemoveItem<
   Attr extends Attributes = Attributes,
-  Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined =
-    | CompositeKeyPart<Attr>
+  Partition extends EntityCompositeKeyPart<Attr> = EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined =
+    | EntityCompositeKeyPart<Attr>
     | undefined
 > extends EntityStreamItemBase<Attr, Partition, Sort> {
   operation: "remove";
@@ -94,8 +94,8 @@ export interface EntityStreamRemoveItem<
 
 export interface EntityStream<
   Attr extends Attributes,
-  Partition extends CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined
+  Partition extends EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined
 > extends EntityStreamSpec<Attr, Partition, Sort> {
   kind: "EntityStream";
   handler: EntityStreamHandler<Attr, Partition, Sort>;
@@ -104,8 +104,8 @@ export interface EntityStream<
 
 export function entityStream<
   Attr extends Attributes,
-  const Partition extends CompositeKeyPart<Attr>,
-  const Sort extends CompositeKeyPart<Attr> | undefined
+  const Partition extends EntityCompositeKeyPart<Attr>,
+  const Sort extends EntityCompositeKeyPart<Attr> | undefined
 >(
   ...args:
     | [

--- a/packages/@eventual/core/src/internal/service-spec.ts
+++ b/packages/@eventual/core/src/internal/service-spec.ts
@@ -1,6 +1,10 @@
 import type openapi from "openapi3-ts";
 import { Attributes } from "../entity/entity.js";
-import { CompositeKeyPart, StreamQueryKey } from "../entity/key.js";
+import {
+  CompositeKeyPart,
+  EntityCompositeKeyPart,
+  StreamQueryKey,
+} from "../entity/key.js";
 import type { FunctionRuntimeProps } from "../function-props.js";
 import type { HttpMethod } from "../http-method.js";
 import type { RestParams } from "../http/command.js";
@@ -205,9 +209,9 @@ export type EntityStreamOperation = "insert" | "modify" | "remove";
 
 export interface EntityStreamOptions<
   Attr extends Attributes = Attributes,
-  Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined =
-    | CompositeKeyPart<Attr>
+  Partition extends EntityCompositeKeyPart<Attr> = EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined =
+    | EntityCompositeKeyPart<Attr>
     | undefined
 > extends FunctionRuntimeProps {
   /**
@@ -228,9 +232,9 @@ export interface EntityStreamOptions<
 
 export interface EntityStreamSpec<
   Attr extends Attributes = Attributes,
-  Partition extends CompositeKeyPart<Attr> = CompositeKeyPart<Attr>,
-  Sort extends CompositeKeyPart<Attr> | undefined =
-    | CompositeKeyPart<Attr>
+  Partition extends EntityCompositeKeyPart<Attr> = EntityCompositeKeyPart<Attr>,
+  Sort extends EntityCompositeKeyPart<Attr> | undefined =
+    | EntityCompositeKeyPart<Attr>
     | undefined
 > {
   name: string;


### PR DESCRIPTION
* fix - we did not support sparse indices as keys could not be optional
* fix - query key tuple should require the partition

Sparse indices allow optional fields to be used in global or local index keys. 

```ts
export const counter = entity("counter5", {
  attributes: {
    n: z.number(),
    namespace: z.union([
      z.literal("different"),
      z.literal("default"),
      z.literal("another"),
    ]),
    id: z.string(),
    optional: z.string().optional(),
  },
  partition: ["namespace", "id"],
});

export const countersByOptional = counter.index("countersOrderedByNamespace", {
  partition: ["id"],
  sort: ["optional"],
});
```