### PR TITLE
fix: make eventual-cli role region-specific

### DIFF
--- a/packages/@eventual/aws-cdk/src/service.ts
+++ b/packages/@eventual/aws-cdk/src/service.ts
@@ -271,7 +271,7 @@ export class Service<S = any> extends Construct {
     const eventualServiceScope = new Construct(systemScope, "EventualService");
 
     const accessRole = new Role(eventualServiceScope, "AccessRole", {
-      roleName: `eventual-cli-${this.serviceName}`,
+      roleName: `eventual-cli-${this.serviceName}-${Stack.of(this).region}`,
       assumedBy: new AccountRootPrincipal(),
     });
 

--- a/packages/@eventual/cli/src/role.ts
+++ b/packages/@eventual/cli/src/role.ts
@@ -7,7 +7,7 @@ export async function assumeCliRole(
 ): Promise<AwsCredentialIdentity> {
   const stsClient = new sts.STSClient({ region });
   const identity = await stsClient.send(new sts.GetCallerIdentityCommand({}));
-  const roleArn = `arn:aws:iam::${identity.Account}:role/eventual-cli-${service}`;
+  const roleArn = `arn:aws:iam::${identity.Account}:role/eventual-cli-${service}-${region}`;
   const { Credentials } = await stsClient.send(
     new sts.AssumeRoleCommand({
       RoleArn: roleArn,


### PR DESCRIPTION
Quick workaround to this problem: https://github.com/functionless/eventual/issues/364

I still think we should add a bootstrap stack.