### PR TITLE
chore: add aws-cdk CLI to root of project

### DIFF
--- a/packages/create-eventual/src/create-new-aws-cdk-project.ts
+++ b/packages/create-eventual/src/create-new-aws-cdk-project.ts
@@ -160,6 +160,7 @@ ${npm("deploy")}
           "@tsconfig/node18": "^1",
           "@types/jest": "^29",
           "@types/node": "^18",
+          "aws-cdk": "^2.80.0",
           esbuild: "^0.16.14",
           typescript: "^5",
         },


### PR DESCRIPTION
To simplify our project template, i'm adding the cdk cli to the root of the project.