### PR TITLE
feat: entity query conditions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,6 +40,7 @@
   "editor.insertSpaces": true,
   "editor.formatOnSave": true,
   "eslint.format.enable": false,
+  "prettier.prettierPath": "./node_modules/prettier",
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.preferences.importModuleSpecifier": "relative"
 }

--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -695,6 +695,36 @@ export const entityIndexTask = task(
           namespace: e.value.namespace,
         }))
       ),
+      allCountersByN
+        .query({
+          id,
+          n: { betweenStart: 2, betweenEnd: 100 },
+        })
+        .then((q) =>
+          q.entries?.map((e) => ({
+            n: e.value.n,
+            namespace: e.value.namespace,
+          }))
+        ),
+      allCountersByN
+        .query({
+          id,
+          n: { greaterThan: 100 },
+        })
+        .then((q) =>
+          q.entries?.map((e) => ({
+            n: e.value.n,
+            namespace: e.value.namespace,
+          }))
+        ),
+      countersByNamespace
+        .query({ id, namespace: { beginsWith: "d" } }, { direction: "DESC" })
+        .then((q) =>
+          q.entries?.map((e) => ({
+            n: e.value.n,
+            namespace: e.value.namespace,
+          }))
+        ),
       // sparse indices only include records with the given field
       countersByOptional2.query({ id }).then((q) =>
         q.entries?.map((e) => ({

--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -698,7 +698,7 @@ export const entityIndexTask = task(
       allCountersByN
         .query({
           id,
-          n: { between: [2, 100] },
+          n: { $between: [2, 100] },
         })
         .then((q) =>
           q.entries?.map((e) => ({
@@ -709,7 +709,7 @@ export const entityIndexTask = task(
       allCountersByN
         .query({
           id,
-          n: { greaterThan: 100 },
+          n: { $gt: 100 },
         })
         .then((q) =>
           q.entries?.map((e) => ({
@@ -718,7 +718,7 @@ export const entityIndexTask = task(
           }))
         ),
       countersByNamespace
-        .query({ id, namespace: { beginsWith: "d" } }, { direction: "DESC" })
+        .query({ id, namespace: { $beginsWith: "d" } }, { direction: "DESC" })
         .then((q) =>
           q.entries?.map((e) => ({
             n: e.value.n,

--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -698,7 +698,7 @@ export const entityIndexTask = task(
       allCountersByN
         .query({
           id,
-          n: { betweenStart: 2, betweenEnd: 100 },
+          n: { between: [2, 100] },
         })
         .then((q) =>
           q.entries?.map((e) => ({

--- a/apps/tests/aws-runtime/test/test-service.ts
+++ b/apps/tests/aws-runtime/test/test-service.ts
@@ -555,6 +555,7 @@ export const counter = entity("counter5", {
       z.literal("different"),
       z.literal("default"),
       z.literal("another"),
+      z.literal("another2"),
     ]),
     id: z.string(),
     optional: z.string().optional(),
@@ -670,6 +671,12 @@ export const entityIndexTask = task(
       n: 1000,
       optional: "hello",
     });
+    await counter.set({
+      namespace: "another2",
+      id,
+      n: 9,
+      optional: "hello",
+    });
     return await Promise.all([
       allCounters.query({ id }).then((q) =>
         q.entries?.map((e) => ({
@@ -709,7 +716,7 @@ export const entityIndexTask = task(
       allCountersByN
         .query({
           id,
-          n: { $gt: 100 },
+          n: { $gt: 1 },
         })
         .then((q) =>
           q.entries?.map((e) => ({
@@ -732,6 +739,15 @@ export const entityIndexTask = task(
           namespace: e.value.namespace,
         }))
       ),
+      // between using a multi-attribute key
+      countersByOptional2
+        .query({ id, $between: [{}, { optional: "hello", n: 10 }] })
+        .then((q) =>
+          q.entries?.map((e) => ({
+            n: e.value.n,
+            namespace: e.value.namespace,
+          }))
+        ),
     ]);
   }
 );

--- a/apps/tests/aws-runtime/test/tester.test.ts
+++ b/apps/tests/aws-runtime/test/tester.test.ts
@@ -134,6 +134,10 @@ eventualRuntimeTestHarness(
             namespace: "default",
             n: 6,
           },
+          {
+            namespace: "another2",
+            n: 9,
+          },
         ]),
         [
           {
@@ -145,6 +149,10 @@ eventualRuntimeTestHarness(
             n: 6,
           },
           {
+            namespace: "another2",
+            n: 9,
+          },
+          {
             namespace: "another",
             n: 1000,
           },
@@ -153,6 +161,10 @@ eventualRuntimeTestHarness(
           {
             namespace: "another",
             n: 1000,
+          },
+          {
+            namespace: "another2",
+            n: 9,
           },
           {
             namespace: "default",
@@ -174,8 +186,16 @@ eventualRuntimeTestHarness(
             namespace: "default",
             n: 6,
           },
+          {
+            namespace: "another2",
+            n: 9,
+          },
         ],
         [
+          {
+            namespace: "another",
+            n: 9,
+          },
           {
             namespace: "another",
             n: 1000,
@@ -193,8 +213,18 @@ eventualRuntimeTestHarness(
         ],
         [
           {
+            namespace: "another2",
+            n: 9,
+          },
+          {
             namespace: "another",
             n: 1000,
+          },
+        ],
+        [
+          {
+            namespace: "another2",
+            n: 9,
           },
         ],
       ],

--- a/apps/tests/aws-runtime/test/tester.test.ts
+++ b/apps/tests/aws-runtime/test/tester.test.ts
@@ -120,8 +120,8 @@ eventualRuntimeTestHarness(
     testCompletion("awsSdkCalls", createAndDestroyWorkflow, "done");
 
     testCompletion("ent", entityWorkflow, [
-      [
-        expect.arrayContaining([
+      {
+        all: expect.arrayContaining([
           {
             namespace: "different",
             n: 1,
@@ -136,10 +136,14 @@ eventualRuntimeTestHarness(
           },
           {
             namespace: "another2",
-            n: 9,
+            n: 0,
           },
         ]),
-        [
+        byN: [
+          {
+            namespace: "another2",
+            n: 0,
+          },
           {
             namespace: "different",
             n: 1,
@@ -149,22 +153,18 @@ eventualRuntimeTestHarness(
             n: 6,
           },
           {
-            namespace: "another2",
-            n: 9,
-          },
-          {
             namespace: "another",
             n: 1000,
           },
         ],
-        [
+        byNamespace: [
           {
             namespace: "another",
             n: 1000,
           },
           {
             namespace: "another2",
-            n: 9,
+            n: 0,
           },
           {
             namespace: "default",
@@ -175,33 +175,29 @@ eventualRuntimeTestHarness(
             n: 1,
           },
         ],
-        [
+        filterByNamespace: [
           {
             namespace: "another",
             n: 1000,
           },
         ],
-        [
+        betweenN: [
+          {
+            namespace: "default",
+            n: 6,
+          },
+        ],
+        greaterThanN: [
           {
             namespace: "default",
             n: 6,
           },
           {
-            namespace: "another2",
-            n: 9,
-          },
-        ],
-        [
-          {
-            namespace: "another",
-            n: 9,
-          },
-          {
             namespace: "another",
             n: 1000,
           },
         ],
-        [
+        reverse: [
           {
             namespace: "different",
             n: 1,
@@ -211,23 +207,23 @@ eventualRuntimeTestHarness(
             n: 6,
           },
         ],
-        [
+        sparse: [
           {
             namespace: "another2",
-            n: 9,
+            n: 0,
           },
           {
             namespace: "another",
             n: 1000,
           },
         ],
-        [
+        inlineBetween: [
           {
             namespace: "another2",
-            n: 9,
+            n: 0,
           },
         ],
-      ],
+      },
       { n: 7 },
       [
         [1, 1],

--- a/apps/tests/aws-runtime/test/tester.test.ts
+++ b/apps/tests/aws-runtime/test/tester.test.ts
@@ -171,6 +171,28 @@ eventualRuntimeTestHarness(
         ],
         [
           {
+            namespace: "default",
+            n: 6,
+          },
+        ],
+        [
+          {
+            namespace: "another",
+            n: 1000,
+          },
+        ],
+        [
+          {
+            namespace: "different",
+            n: 1,
+          },
+          {
+            namespace: "default",
+            n: 6,
+          },
+        ],
+        [
+          {
             namespace: "another",
             n: 1000,
           },

--- a/packages/@eventual/aws-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/aws-runtime/src/stores/entity-store.ts
@@ -524,11 +524,11 @@ function getSortKeyExpressionAndAttribute(
         attributeValueMap: {
           ":skLeft": keyPartAttributeValue(
             keyPart,
-            keyPart.condition.betweenStart
+            keyPart.condition.between[0]
           ),
           ":skRight": keyPartAttributeValue(
             keyPart,
-            keyPart.condition.betweenEnd
+            keyPart.condition.between[1]
           ),
         },
       };

--- a/packages/@eventual/aws-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/aws-runtime/src/stores/entity-store.ts
@@ -460,6 +460,7 @@ export class AWSEntityStore extends EntityStore {
   }
 
   private entityKey(key: NormalizedEntityCompositeKey) {
+    console.debug("Key", JSON.stringify(key));
     const marshalledKey = marshall(
       {
         [key.partition.keyAttribute]: key.partition.keyValue,
@@ -467,6 +468,7 @@ export class AWSEntityStore extends EntityStore {
       },
       { removeUndefinedValues: true }
     );
+    console.debug("Marshalled Key", JSON.stringify(marshalledKey));
     return marshalledKey;
   }
 

--- a/packages/@eventual/aws-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/aws-runtime/src/stores/entity-store.ts
@@ -35,6 +35,7 @@ import {
   EntityProvider,
   EntityStore,
   getLazy,
+  isNormalizedEntityQueryKeyConditionPart,
   LazyValue,
   NormalizedEntityCompositeKey,
   NormalizedEntityCompositeKeyComplete,
@@ -515,7 +516,7 @@ function getSortKeyExpressionAndAttribute(
   const attributeNameKey = formatAttributeNameMapKey(keyPart.keyAttribute);
 
   // if the key part is a condition key part
-  if ("condition" in keyPart) {
+  if (isNormalizedEntityQueryKeyConditionPart(keyPart)) {
     if (isBetweenQueryKeyCondition(keyPart.condition)) {
       return {
         attribute: keyPart.keyAttribute,

--- a/packages/@eventual/aws-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/aws-runtime/src/stores/entity-store.ts
@@ -524,11 +524,11 @@ function getSortKeyExpressionAndAttribute(
         attributeValueMap: {
           ":skLeft": keyPartAttributeValue(
             keyPart,
-            keyPart.condition.between[0]
+            keyPart.condition.$between[0]
           ),
           ":skRight": keyPartAttributeValue(
             keyPart,
-            keyPart.condition.between[1]
+            keyPart.condition.$between[1]
           ),
         },
       };
@@ -537,17 +537,17 @@ function getSortKeyExpressionAndAttribute(
         keyPart.condition
       )
         ? [
-            keyPart.condition.beginsWith,
+            keyPart.condition.$beginsWith,
             `begins_with(${attributeNameKey}, :sk)`,
           ]
         : isLessThanQueryKeyCondition(keyPart.condition)
-        ? [keyPart.condition.lessThan, `${attributeNameKey} < :sk`]
+        ? [keyPart.condition.$lt, `${attributeNameKey} < :sk`]
         : isLessThanEqualsQueryKeyCondition(keyPart.condition)
-        ? [keyPart.condition.lessThanEquals, `${attributeNameKey} <= :sk`]
+        ? [keyPart.condition.$lte, `${attributeNameKey} <= :sk`]
         : isGreaterThanQueryKeyCondition(keyPart.condition)
-        ? [keyPart.condition.greaterThan, `${attributeNameKey} > :sk`]
+        ? [keyPart.condition.$gt, `${attributeNameKey} > :sk`]
         : isGreaterThanEqualsQueryKeyCondition(keyPart.condition)
-        ? [keyPart.condition.greaterThanEquals, `${attributeNameKey} >= :sk`]
+        ? [keyPart.condition.$gte, `${attributeNameKey} >= :sk`]
         : assertNever(keyPart.condition);
 
       return {

--- a/packages/@eventual/core-runtime/src/local/stores/entity-store.ts
+++ b/packages/@eventual/core-runtime/src/local/stores/entity-store.ts
@@ -418,8 +418,8 @@ function filterEntryBySortKey(
   } else if (isNormalizedEntityQueryKeyConditionPart(querySortKey)) {
     if (isBetweenQueryKeyCondition(querySortKey.condition)) {
       return (
-        entrySortKeyValue >= querySortKey.condition.betweenStart &&
-        entrySortKeyValue <= querySortKey.condition.betweenEnd
+        entrySortKeyValue >= querySortKey.condition.between[0] &&
+        entrySortKeyValue <= querySortKey.condition.between[1]
       );
     } else if (isBeginsWithQueryKeyCondition(querySortKey.condition)) {
       return typeof entrySortKeyValue === "string"

--- a/packages/@eventual/core-runtime/src/local/stores/entity-store.ts
+++ b/packages/@eventual/core-runtime/src/local/stores/entity-store.ts
@@ -32,6 +32,7 @@ import {
   NormalizedEntityTransactItem,
   convertNormalizedEntityKeyToMap,
   isCompleteKey,
+  isNormalizedEntityQueryKeyConditionPart,
   normalizeCompositeKey,
 } from "../../stores/entity-store.js";
 import { deserializeCompositeKey, serializeCompositeKey } from "../../utils.js";
@@ -414,7 +415,7 @@ function filterEntryBySortKey(
   // in which case it should not be placed in the index at all
   if (!isCompleteKey(entryKey) || entrySortKeyValue === undefined) {
     return false;
-  } else if ("condition" in querySortKey) {
+  } else if (isNormalizedEntityQueryKeyConditionPart(querySortKey)) {
     if (isBetweenQueryKeyCondition(querySortKey.condition)) {
       return (
         entrySortKeyValue >= querySortKey.condition.betweenStart &&

--- a/packages/@eventual/core-runtime/src/local/stores/entity-store.ts
+++ b/packages/@eventual/core-runtime/src/local/stores/entity-store.ts
@@ -418,21 +418,21 @@ function filterEntryBySortKey(
   } else if (isNormalizedEntityQueryKeyConditionPart(querySortKey)) {
     if (isBetweenQueryKeyCondition(querySortKey.condition)) {
       return (
-        entrySortKeyValue >= querySortKey.condition.between[0] &&
-        entrySortKeyValue <= querySortKey.condition.between[1]
+        entrySortKeyValue >= querySortKey.condition.$between[0] &&
+        entrySortKeyValue <= querySortKey.condition.$between[1]
       );
     } else if (isBeginsWithQueryKeyCondition(querySortKey.condition)) {
       return typeof entrySortKeyValue === "string"
-        ? entrySortKeyValue.startsWith(querySortKey.condition.beginsWith)
+        ? entrySortKeyValue.startsWith(querySortKey.condition.$beginsWith)
         : false;
     } else if (isLessThanQueryKeyCondition(querySortKey.condition)) {
-      return entrySortKeyValue < querySortKey.condition.lessThan;
+      return entrySortKeyValue < querySortKey.condition.$lt;
     } else if (isLessThanEqualsQueryKeyCondition(querySortKey.condition)) {
-      return entrySortKeyValue <= querySortKey.condition.lessThanEquals;
+      return entrySortKeyValue <= querySortKey.condition.$lte;
     } else if (isGreaterThanQueryKeyCondition(querySortKey.condition)) {
-      return entrySortKeyValue > querySortKey.condition.greaterThan;
+      return entrySortKeyValue > querySortKey.condition.$gt;
     } else if (isGreaterThanEqualsQueryKeyCondition(querySortKey.condition)) {
-      return entrySortKeyValue >= querySortKey.condition.greaterThanEquals;
+      return entrySortKeyValue >= querySortKey.condition.$gte;
     }
 
     assertNever(querySortKey.condition);

--- a/packages/@eventual/core-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/core-runtime/src/stores/entity-store.ts
@@ -295,7 +295,7 @@ export interface NormalizedEntityQueryKeyConditionPart
    * ```ts
    * {
    *   "sortA": "A",
-   *   "sortB": { betweenStart: "B", betweenEnd: "C", }
+   *   "sortB": { between: ["B", "C"] }
    * }
    * ```
    *
@@ -303,7 +303,7 @@ export interface NormalizedEntityQueryKeyConditionPart
    *
    * ```ts
    * {
-   *   condition: { betweenStart: "A#B", betweenEnd: "A#C" }
+   *   condition: { between: ["A#B", "A#C"] }
    * }
    * ```
    */
@@ -535,14 +535,16 @@ function formatNormalizedQueryPart(
       keyAttribute: keyPart.keyAttribute,
       condition: isBetweenQueryKeyCondition(condition)
         ? {
-            betweenStart: formatKeyPrefixConditionValue(
-              condition.betweenStart,
-              keyValuePrefix
-            ),
-            betweenEnd: formatKeyPrefixConditionValue(
-              condition.betweenEnd,
-              keyValuePrefix
-            ),
+            between: [
+              formatKeyPrefixConditionValue(
+                condition.between[0],
+                keyValuePrefix
+              ),
+              formatKeyPrefixConditionValue(
+                condition.between[1],
+                keyValuePrefix
+              ),
+            ],
           }
         : isBeginsWithQueryKeyCondition(condition)
         ? {

--- a/packages/@eventual/core-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/core-runtime/src/stores/entity-store.ts
@@ -535,7 +535,7 @@ function formatNormalizedQueryPart(
               keyValuePrefix
             ),
             betweenEnd: formatKeyPrefixConditionValue(
-              condition.betweenStart,
+              condition.betweenEnd,
               keyValuePrefix
             ),
           }

--- a/packages/@eventual/core-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/core-runtime/src/stores/entity-store.ts
@@ -310,6 +310,12 @@ export interface NormalizedEntityQueryKeyConditionPart
   condition: QueryKeyCondition;
 }
 
+export function isNormalizedEntityQueryKeyConditionPart(
+  key: NormalizedEntityQueryKeyPart
+): key is NormalizedEntityQueryKeyConditionPart {
+  return !!(key as NormalizedEntityQueryKeyConditionPart).condition;
+}
+
 export function isCompleteKeyPart(
   key: NormalizedEntityKeyPart
 ): key is NormalizedEntityKeyCompletePart {

--- a/packages/@eventual/core-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/core-runtime/src/stores/entity-store.ts
@@ -308,7 +308,6 @@ export interface NormalizedEntityQueryKeyConditionPart
    * ```
    */
   condition: QueryKeyCondition;
-  partialValue: true;
 }
 
 export function isCompleteKeyPart(
@@ -387,11 +386,11 @@ export function normalizeCompositeKey<E extends Entity>(
 }
 
 /**
- * Generate properties for an entity key given the key definition and key values.
+ * Generate properties for an entity query key given the key definition and key values or conditions.
  */
 export function normalizeCompositeQueryKey<E extends Entity>(
   entity: E | KeyDefinition,
-  key: Partial<QueryKey>
+  key: QueryKey
 ): NormalizedEntityCompositeQueryKey {
   const keyDef = "partition" in entity ? entity : entity.key;
 
@@ -494,7 +493,7 @@ function formatNormalizedQueryPart(
   if (
     hasCondition &&
     ((isPartial && queryConditionIndex > missingValueIndex) ||
-      queryConditionIndex !== keyPart.attributes.length)
+      queryConditionIndex !== keyPart.attributes.length - 1)
   ) {
     throw new Error(
       "Query Key condition must be the final value provided key attribute."
@@ -575,7 +574,6 @@ function formatNormalizedQueryPart(
             ),
           }
         : assertNever(condition),
-      partialValue: true,
     };
   }
 

--- a/packages/@eventual/core-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/core-runtime/src/stores/entity-store.ts
@@ -468,7 +468,7 @@ function formatNormalizeSortKeyPart(
   if (!keyDef.sort) {
     return undefined;
   }
-  return formatNormalizedPart(keyDef.partition, (p, i) =>
+  return formatNormalizedPart(keyDef.sort, (p, i) =>
     Array.isArray(key)
       ? key[keyDef.partition.attributes.length + i]
       : (key as KeyMap)[p]
@@ -730,7 +730,7 @@ function generateBetweenConditionFromInlineBetween(
     (left.keyValue === undefined || right.keyValue === undefined)
   ) {
     throw new Error(
-      "Between conditions cannot be empty when the field type is number"
+      "Between conditions cannot be empty when the field type is number."
     );
   }
   return { $between: [left.keyValue ?? "", right.keyValue ?? ""] };

--- a/packages/@eventual/core-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/core-runtime/src/stores/entity-store.ts
@@ -535,51 +535,39 @@ function formatNormalizedQueryPart(
       keyAttribute: keyPart.keyAttribute,
       condition: isBetweenQueryKeyCondition(condition)
         ? {
-            between: [
+            $between: [
               formatKeyPrefixConditionValue(
-                condition.between[0],
+                condition.$between[0],
                 keyValuePrefix
               ),
               formatKeyPrefixConditionValue(
-                condition.between[1],
+                condition.$between[1],
                 keyValuePrefix
               ),
             ],
           }
         : isBeginsWithQueryKeyCondition(condition)
         ? {
-            beginsWith: formatKeyPrefixConditionValue(
-              condition.beginsWith,
+            $beginsWith: formatKeyPrefixConditionValue(
+              condition.$beginsWith,
               keyValuePrefix
             ) as string,
           }
         : isLessThanQueryKeyCondition(condition)
         ? {
-            lessThan: formatKeyPrefixConditionValue(
-              condition.lessThan,
-              keyValuePrefix
-            ),
+            $lt: formatKeyPrefixConditionValue(condition.$lt, keyValuePrefix),
           }
         : isLessThanEqualsQueryKeyCondition(condition)
         ? {
-            lessThanEquals: formatKeyPrefixConditionValue(
-              condition.lessThanEquals,
-              keyValuePrefix
-            ),
+            $lte: formatKeyPrefixConditionValue(condition.$lte, keyValuePrefix),
           }
         : isGreaterThanQueryKeyCondition(condition)
         ? {
-            greaterThan: formatKeyPrefixConditionValue(
-              condition.greaterThan,
-              keyValuePrefix
-            ),
+            $gt: formatKeyPrefixConditionValue(condition.$gt, keyValuePrefix),
           }
         : isGreaterThanEqualsQueryKeyCondition(condition)
         ? {
-            greaterThanEquals: formatKeyPrefixConditionValue(
-              condition.greaterThanEquals,
-              keyValuePrefix
-            ),
+            $gte: formatKeyPrefixConditionValue(condition.$gte, keyValuePrefix),
           }
         : assertNever(condition),
     };

--- a/packages/@eventual/core-runtime/test/entity-store.test.ts
+++ b/packages/@eventual/core-runtime/test/entity-store.test.ts
@@ -133,7 +133,7 @@ describe("normalizeCompositeQueryKey", () => {
         },
         {
           part: "a",
-          sort: { beginsWith: "b" } as any,
+          sort: { $beginsWith: "b" } as any,
         }
       )
     ).toEqual<NormalizedEntityCompositeQueryKey>({
@@ -148,8 +148,8 @@ describe("normalizeCompositeQueryKey", () => {
       sort: {
         attributes: ["sort"],
         keyAttribute: "sort",
-        condition: { beginsWith: "b" },
-        parts: [{ field: "sort", value: { beginsWith: "b" } }],
+        condition: { $beginsWith: "b" },
+        parts: [{ field: "sort", value: { $beginsWith: "b" } }],
         type: "string",
       },
     });
@@ -173,7 +173,7 @@ describe("normalizeCompositeQueryKey", () => {
         {
           part: "a",
           sort: "b",
-          sort2: { beginsWith: "c" } as any,
+          sort2: { $beginsWith: "c" } as any,
         }
       )
     ).toEqual<NormalizedEntityCompositeQueryKey>({
@@ -188,10 +188,10 @@ describe("normalizeCompositeQueryKey", () => {
       sort: {
         attributes: ["sort", "sort2"],
         keyAttribute: "sort|sort2",
-        condition: { beginsWith: "b#c" },
+        condition: { $beginsWith: "b#c" },
         parts: [
           { field: "sort", value: "b" },
-          { field: "sort2", value: { beginsWith: "c" } },
+          { field: "sort2", value: { $beginsWith: "c" } },
         ],
         type: "string",
       },

--- a/packages/@eventual/core-runtime/test/entity-store.test.ts
+++ b/packages/@eventual/core-runtime/test/entity-store.test.ts
@@ -1,0 +1,200 @@
+import {
+  NormalizedEntityCompositeQueryKey,
+  normalizeCompositeQueryKey,
+} from "../src/stores/entity-store.js";
+
+describe("normalizeCompositeQueryKey", () => {
+  test("should normalize composite query key", () => {
+    expect(
+      normalizeCompositeQueryKey(
+        {
+          partition: {
+            attributes: ["part"],
+            keyAttribute: "part",
+            type: "string",
+          },
+          sort: { attributes: ["sort"], keyAttribute: "sort", type: "string" },
+        },
+        {
+          part: "a",
+          sort: "b",
+        }
+      )
+    ).toEqual<NormalizedEntityCompositeQueryKey>({
+      partition: {
+        attributes: ["part"],
+        keyAttribute: "part",
+        keyValue: "a",
+        partialValue: false,
+        parts: [{ field: "part", value: "a" }],
+        type: "string",
+      },
+      sort: {
+        attributes: ["sort"],
+        keyAttribute: "sort",
+        keyValue: "b",
+        partialValue: false,
+        parts: [{ field: "sort", value: "b" }],
+        type: "string",
+      },
+    });
+  });
+
+  test("should normalize composite query key without a sort key", () => {
+    expect(
+      normalizeCompositeQueryKey(
+        {
+          partition: {
+            attributes: ["part"],
+            keyAttribute: "part",
+            type: "string",
+          },
+        },
+        {
+          part: "a",
+          sort: "b",
+        }
+      )
+    ).toEqual<NormalizedEntityCompositeQueryKey>({
+      partition: {
+        attributes: ["part"],
+        keyAttribute: "part",
+        keyValue: "a",
+        partialValue: false,
+        parts: [{ field: "part", value: "a" }],
+        type: "string",
+      },
+    });
+  });
+
+  test("should normalize composite query key with a multi-attribute partition key", () => {
+    expect(
+      normalizeCompositeQueryKey(
+        {
+          partition: {
+            attributes: ["part", "part2"],
+            keyAttribute: "part|part2",
+            type: "string",
+          },
+        },
+        {
+          part: "a",
+          part2: 1,
+          sort: "b",
+        }
+      )
+    ).toEqual<NormalizedEntityCompositeQueryKey>({
+      partition: {
+        attributes: ["part", "part2"],
+        keyAttribute: "part|part2",
+        keyValue: "a#1",
+        partialValue: false,
+        parts: [
+          { field: "part", value: "a" },
+          { field: "part2", value: 1 },
+        ],
+        type: "string",
+      },
+    });
+  });
+
+  test("should fail to normalize composite query key with a partial partition key", () => {
+    expect(() =>
+      normalizeCompositeQueryKey(
+        {
+          partition: {
+            attributes: ["part", "part2"],
+            keyAttribute: "part|part2",
+            type: "string",
+          },
+        },
+        {
+          part: "a",
+          sort: "b",
+        }
+      )
+    ).toThrow(new Error("Query key partition part cannot be partial"));
+  });
+
+  test("should normalize composite key with sort conditions", () => {
+    expect(
+      normalizeCompositeQueryKey(
+        {
+          partition: {
+            attributes: ["part"],
+            keyAttribute: "part",
+            type: "string",
+          },
+          sort: {
+            attributes: ["sort"],
+            keyAttribute: "sort",
+            type: "string",
+          },
+        },
+        {
+          part: "a",
+          sort: { beginsWith: "b" } as any,
+        }
+      )
+    ).toEqual<NormalizedEntityCompositeQueryKey>({
+      partition: {
+        attributes: ["part"],
+        keyAttribute: "part",
+        keyValue: "a",
+        partialValue: false,
+        parts: [{ field: "part", value: "a" }],
+        type: "string",
+      },
+      sort: {
+        attributes: ["sort"],
+        keyAttribute: "sort",
+        condition: { beginsWith: "b" },
+        parts: [{ field: "sort", value: { beginsWith: "b" } }],
+        type: "string",
+      },
+    });
+  });
+
+  test("should normalize composite key with multi-attribute sort conditions", () => {
+    expect(
+      normalizeCompositeQueryKey(
+        {
+          partition: {
+            attributes: ["part"],
+            keyAttribute: "part",
+            type: "string",
+          },
+          sort: {
+            attributes: ["sort", "sort2"],
+            keyAttribute: "sort|sort2",
+            type: "string",
+          },
+        },
+        {
+          part: "a",
+          sort: "b",
+          sort2: { beginsWith: "c" } as any,
+        }
+      )
+    ).toEqual<NormalizedEntityCompositeQueryKey>({
+      partition: {
+        attributes: ["part"],
+        keyAttribute: "part",
+        keyValue: "a",
+        partialValue: false,
+        parts: [{ field: "part", value: "a" }],
+        type: "string",
+      },
+      sort: {
+        attributes: ["sort", "sort2"],
+        keyAttribute: "sort|sort2",
+        condition: { beginsWith: "b#c" },
+        parts: [
+          { field: "sort", value: "b" },
+          { field: "sort2", value: { beginsWith: "c" } },
+        ],
+        type: "string",
+      },
+    });
+  });
+});

--- a/packages/@eventual/core/src/entity/key.ts
+++ b/packages/@eventual/core/src/entity/key.ts
@@ -246,6 +246,8 @@ export type ProgressiveQueryKey<
 /**
  * Supports betweens condition using multiple sort attribute parts.
  *
+ * At least one attribute must be present in the left and right side.
+ *
  * BETWEEN "a" and "c#b"
  * {
  *    $between: [{sort1: "a"}, {sort1: "c", sort2: "b"}]
@@ -260,7 +262,19 @@ export type BetweenProgressiveKeyCondition<
   Attr extends Attributes,
   Sort extends readonly (keyof Attr)[]
 > = {
-  $between: [ProgressiveKey<Attr, Sort>, ProgressiveKey<Attr, Sort>];
+  $between: Sort extends readonly [
+    infer k extends keyof Attr,
+    ...infer ks extends readonly (keyof Attr)[]
+  ]
+    ? [
+        ProgressiveKey<Attr, ks> & {
+          [sk in k]: Extract<Attr[sk], KeyValue>;
+        },
+        ProgressiveKey<Attr, ks> & {
+          [sk in k]: Extract<Attr[sk], KeyValue>;
+        }
+      ]
+    : never;
 };
 
 export type ProgressiveKey<

--- a/packages/@eventual/core/src/entity/key.ts
+++ b/packages/@eventual/core/src/entity/key.ts
@@ -146,8 +146,7 @@ export type QueryKeyCondition<Value extends KeyValue = KeyValue> =
  * Note: numeric multi-attribute key parts are treated as strings.
  */
 export interface BetweenQueryKeyCondition<Value extends KeyValue = KeyValue> {
-  betweenStart: t.LiteralToPrimitive<Value>;
-  betweenEnd: t.LiteralToPrimitive<Value>;
+  between: [t.LiteralToPrimitive<Value>, t.LiteralToPrimitive<Value>];
 }
 
 /**

--- a/packages/@eventual/core/src/entity/key.ts
+++ b/packages/@eventual/core/src/entity/key.ts
@@ -146,7 +146,7 @@ export type QueryKeyCondition<Value extends KeyValue = KeyValue> =
  * Note: numeric multi-attribute key parts are treated as strings.
  */
 export interface BetweenQueryKeyCondition<Value extends KeyValue = KeyValue> {
-  between: [t.LiteralToPrimitive<Value>, t.LiteralToPrimitive<Value>];
+  $between: [t.LiteralToPrimitive<Value>, t.LiteralToPrimitive<Value>];
 }
 
 /**
@@ -159,7 +159,7 @@ export interface BetweenQueryKeyCondition<Value extends KeyValue = KeyValue> {
 export interface BeginsWithQueryKeyCondition<
   Value extends KeyValue = KeyValue
 > {
-  beginsWith: Extract<t.LiteralToPrimitive<Value>, string>;
+  $beginsWith: Extract<t.LiteralToPrimitive<Value>, string>;
 }
 
 /**
@@ -168,7 +168,7 @@ export interface BeginsWithQueryKeyCondition<
  * Note: numeric multi-attribute key parts are treated as strings.
  */
 export interface LessThanQueryKeyCondition<Value extends KeyValue = KeyValue> {
-  lessThan: t.LiteralToPrimitive<Value>;
+  $lt: t.LiteralToPrimitive<Value>;
 }
 
 /**
@@ -179,7 +179,7 @@ export interface LessThanQueryKeyCondition<Value extends KeyValue = KeyValue> {
 export interface LessThanEqualsQueryKeyCondition<
   Value extends KeyValue = KeyValue
 > {
-  lessThanEquals: t.LiteralToPrimitive<Value>;
+  $lte: t.LiteralToPrimitive<Value>;
 }
 
 /**
@@ -190,7 +190,7 @@ export interface LessThanEqualsQueryKeyCondition<
 export interface GreaterThanQueryKeyCondition<
   Value extends KeyValue = KeyValue
 > {
-  greaterThan: t.LiteralToPrimitive<Value>;
+  $gt: t.LiteralToPrimitive<Value>;
 }
 
 /**
@@ -201,7 +201,7 @@ export interface GreaterThanQueryKeyCondition<
 export interface GreaterThanEqualsQueryKeyCondition<
   Value extends KeyValue = KeyValue
 > {
-  greaterThanEquals: t.LiteralToPrimitive<Value>;
+  $gte: t.LiteralToPrimitive<Value>;
 }
 
 export type ProgressiveTupleQueryKey<

--- a/packages/@eventual/core/src/internal/entity-hook.ts
+++ b/packages/@eventual/core/src/internal/entity-hook.ts
@@ -32,7 +32,7 @@ export type EntityHook = {
   queryIndex(
     entityName: string,
     indexName: string,
-    queryKey: QueryKey,
+    queryKey: QueryKey<any, any, any>,
     options?: EntityQueryOptions
   ): Promise<EntityQueryResult>;
   scanIndex(

--- a/packages/@eventual/core/src/internal/entity.ts
+++ b/packages/@eventual/core/src/internal/entity.ts
@@ -64,35 +64,35 @@ export function computeKeyDefinition(
 export function isBetweenQueryKeyCondition(
   condition: QueryKeyCondition
 ): condition is BetweenQueryKeyCondition {
-  return "between" in condition;
+  return "$between" in condition;
 }
 
 export function isBeginsWithQueryKeyCondition(
   condition: QueryKeyCondition
 ): condition is BeginsWithQueryKeyCondition {
-  return "beginsWith" in condition;
+  return "$beginsWith" in condition;
 }
 
 export function isLessThanQueryKeyCondition(
   condition: QueryKeyCondition
 ): condition is LessThanQueryKeyCondition {
-  return "lessThan" in condition;
+  return "$lt" in condition;
 }
 
 export function isLessThanEqualsQueryKeyCondition(
   condition: QueryKeyCondition
 ): condition is LessThanEqualsQueryKeyCondition {
-  return "lessThanEquals" in condition;
+  return "$lte" in condition;
 }
 
 export function isGreaterThanQueryKeyCondition(
   condition: QueryKeyCondition
 ): condition is GreaterThanQueryKeyCondition {
-  return "greaterThan" in condition;
+  return "$gt" in condition;
 }
 
 export function isGreaterThanEqualsQueryKeyCondition(
   condition: QueryKeyCondition
 ): condition is GreaterThanEqualsQueryKeyCondition {
-  return "greaterThanEquals" in condition;
+  return "$gte" in condition;
 }

--- a/packages/@eventual/core/src/internal/entity.ts
+++ b/packages/@eventual/core/src/internal/entity.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 import type {
   BeginsWithQueryKeyCondition,
+  BetweenProgressiveKeyCondition,
   BetweenQueryKeyCondition,
   CompositeKeyPart,
   GreaterThanEqualsQueryKeyCondition,
   GreaterThanQueryKeyCondition,
   LessThanEqualsQueryKeyCondition,
   LessThanQueryKeyCondition,
+  QueryKey,
   QueryKeyCondition,
 } from "../entity/key.js";
 
@@ -59,6 +61,12 @@ export function computeKeyDefinition(
       attributes: keyAttributes,
     };
   }
+}
+
+export function keyHasInlineBetween<Q extends QueryKey<any, any, any>>(
+  key: Q
+): key is Q & BetweenProgressiveKeyCondition<any, any> {
+  return "$between" in key;
 }
 
 export function isBetweenQueryKeyCondition(

--- a/packages/@eventual/core/src/internal/entity.ts
+++ b/packages/@eventual/core/src/internal/entity.ts
@@ -64,7 +64,7 @@ export function computeKeyDefinition(
 export function isBetweenQueryKeyCondition(
   condition: QueryKeyCondition
 ): condition is BetweenQueryKeyCondition {
-  return "betweenStart" in condition;
+  return "between" in condition;
 }
 
 export function isBeginsWithQueryKeyCondition(

--- a/packages/@eventual/core/src/internal/entity.ts
+++ b/packages/@eventual/core/src/internal/entity.ts
@@ -1,5 +1,14 @@
 import { z } from "zod";
-import type { CompositeKeyPart } from "../entity/key.js";
+import type {
+  BeginsWithQueryKeyCondition,
+  BetweenQueryKeyCondition,
+  CompositeKeyPart,
+  GreaterThanEqualsQueryKeyCondition,
+  GreaterThanQueryKeyCondition,
+  LessThanEqualsQueryKeyCondition,
+  LessThanQueryKeyCondition,
+  QueryKeyCondition,
+} from "../entity/key.js";
 
 export interface KeyDefinitionPart {
   type: "number" | "string";
@@ -50,4 +59,40 @@ export function computeKeyDefinition(
       attributes: keyAttributes,
     };
   }
+}
+
+export function isBetweenQueryKeyCondition(
+  condition: QueryKeyCondition
+): condition is BetweenQueryKeyCondition {
+  return "betweenStart" in condition;
+}
+
+export function isBeginsWithQueryKeyCondition(
+  condition: QueryKeyCondition
+): condition is BeginsWithQueryKeyCondition {
+  return "beginsWith" in condition;
+}
+
+export function isLessThanQueryKeyCondition(
+  condition: QueryKeyCondition
+): condition is LessThanQueryKeyCondition {
+  return "lessThan" in condition;
+}
+
+export function isLessThanEqualsQueryKeyCondition(
+  condition: QueryKeyCondition
+): condition is LessThanEqualsQueryKeyCondition {
+  return "lessThanEquals" in condition;
+}
+
+export function isGreaterThanQueryKeyCondition(
+  condition: QueryKeyCondition
+): condition is GreaterThanQueryKeyCondition {
+  return "greaterThan" in condition;
+}
+
+export function isGreaterThanEqualsQueryKeyCondition(
+  condition: QueryKeyCondition
+): condition is GreaterThanEqualsQueryKeyCondition {
+  return "greaterThanEquals" in condition;
 }


### PR DESCRIPTION
Adds the ability to provide query conditions in place of concrete key attributes for the sort key.

* Between
* Begins with - only string values
* Less/Greater Than [Equal]

```ts
myEntity.query({
   part: "hello",
   sort: { $between: [1, 100] }
});

myEntity.query({
   part: "hello",
   sort1: "a",
   sort2: { $gt: "b" }
});

myEntity.query({
   part: "hello",
   $between: [{ sort1: "a", sort2: "1" }, { sort1: "b", sort2: "2" }]
});
```

Caveats:
* Numeric fields will be evaluated as strings when part of a multi-attribute key part.
   * ex: `["name", "age"]`, `{ name: "sam", age: { $gt: 30 } }` - greatThan 30 will use string based "30" and not numeric

----

* ~~TODO: add documentation~~

