### PR TITLE
feat: allow for all BucketProps as overrides

### DIFF
--- a/packages/@eventual/aws-cdk/src/bucket-service.ts
+++ b/packages/@eventual/aws-cdk/src/bucket-service.ts
@@ -24,7 +24,11 @@ import { CorsHttpMethod } from "@aws-cdk/aws-apigatewayv2-alpha";
 import type { SearchService } from "./search/search-service";
 
 export type BucketOverrides<Service> = Partial<
-  ServiceEntityProps<Service, "Bucket", BucketRuntimeOverrides>
+  ServiceEntityProps<
+    Service,
+    "Bucket",
+    BucketRuntimeOverrides & Partial<s3.BucketProps>
+  >
 >;
 
 export type BucketNotificationHandlerOverrides<Service> = Partial<
@@ -174,6 +178,7 @@ class Bucket extends Construct {
       props.serviceProps.bucketOverrides?.[props.bucket.name];
 
     this.bucket = new s3.Bucket(this, "Bucket", {
+      ...bucketOverrides,
       cors:
         props.serviceProps.cors &&
         props.serviceProps.cors.allowMethods &&
@@ -204,14 +209,14 @@ class Bucket extends Construct {
               },
             ]
           : undefined,
-      bucketName: bucketOverrides?.bucketName
-        ? bucketOverrides?.bucketName
-        : bucketServiceBucketName(
-            props.serviceProps.serviceName,
-            props.bucket.name
-          ),
-      autoDeleteObjects: true,
-      removalPolicy: RemovalPolicy.DESTROY,
+      bucketName:
+        bucketOverrides?.bucketName ??
+        bucketServiceBucketName(
+          props.serviceProps.serviceName,
+          props.bucket.name
+        ),
+      autoDeleteObjects: bucketOverrides?.autoDeleteObjects ?? true,
+      removalPolicy: bucketOverrides?.removalPolicy ?? RemovalPolicy.DESTROY,
     });
 
     const bucketHandlerScope = new Construct(this, "BucketHandlers");

--- a/packages/@eventual/aws-cdk/src/bucket-service.ts
+++ b/packages/@eventual/aws-cdk/src/bucket-service.ts
@@ -217,6 +217,7 @@ class Bucket extends Construct {
         ),
       autoDeleteObjects: bucketOverrides?.autoDeleteObjects ?? true,
       removalPolicy: bucketOverrides?.removalPolicy ?? RemovalPolicy.DESTROY,
+      versioned: bucketOverrides?.versioned ?? props.bucket.options?.versioned,
     });
 
     const bucketHandlerScope = new Construct(this, "BucketHandlers");

--- a/packages/@eventual/compiler/src/eventual-infer.ts
+++ b/packages/@eventual/compiler/src/eventual-infer.ts
@@ -140,6 +140,7 @@ export function inferFromMemory(openApi: ServiceSpec["openApi"]): ServiceSpec {
               sourceLocation: s.sourceLocation,
             } satisfies BucketNotificationHandlerSpec)
         ),
+        options: b.options,
       })),
     },
     entities: {

--- a/packages/@eventual/core/src/bucket.ts
+++ b/packages/@eventual/core/src/bucket.ts
@@ -21,6 +21,7 @@ export type PresignedUrlOperation = "put" | "get" | "head" | "delete";
 export interface Bucket<Name extends string = string>
   extends Omit<BucketSpec<Name>, "handlers"> {
   kind: "Bucket";
+  options: BucketOptions | undefined;
   handlers: BucketNotificationHandler[];
   /**
    * Gets an object from the gets, returns undefined if the object key doesn't exist.
@@ -121,12 +122,20 @@ export interface Bucket<Name extends string = string>
   ): BucketNotificationHandler<Name>;
 }
 
-export function bucket<Name extends string = string>(name: Name): Bucket<Name> {
+export interface BucketOptions {
+  versioned?: boolean;
+}
+
+export function bucket<Name extends string = string>(
+  name: Name,
+  options?: BucketOptions
+): Bucket<Name> {
   const handlers: BucketNotificationHandler[] = [];
   return registerEventualResource("Bucket", {
     name,
     handlers,
     kind: "Bucket",
+    options,
     get(...args) {
       return getEventualCallHook().registerEventualCall(
         createEventualCall<BucketCall>(EventualCallKind.BucketCall, {

--- a/packages/@eventual/core/src/internal/service-spec.ts
+++ b/packages/@eventual/core/src/internal/service-spec.ts
@@ -16,6 +16,7 @@ import type {
 } from "../subscription.js";
 import { KeyDefinition } from "./entity.js";
 import type { TaskSpec } from "./task.js";
+import { BucketOptions } from "../bucket.js";
 
 /**
  * Specification for an Eventual application
@@ -177,6 +178,7 @@ export interface WorkflowSpec<Name extends string = string> {
 export interface BucketSpec<Name extends string = string> {
   name: Name;
   handlers: BucketNotificationHandlerSpec[];
+  options: BucketOptions | undefined;
 }
 
 export interface IndexSpec extends opensearchtypes.IndicesIndexState {


### PR DESCRIPTION
I needed to be able to enable versioning on a bucket and noticed that we did not have the full escape hatch enabled for buckets.
- [x] allow all BucketProps as overrides on CDK side
- [x] add `BucketOptions` on eventual side and allow `versioned` property. Will add to this as needed.