### PR TITLE
fix: do not import @eventual/core/internal in @eventual/client

### DIFF
--- a/packages/@eventual/client/src/http-eventual-client.ts
+++ b/packages/@eventual/client/src/http-eventual-client.ts
@@ -19,9 +19,8 @@ import {
   Transaction,
   Workflow,
 } from "@eventual/core";
-import {
+import type {
   EventualService,
-  EVENTUAL_SYSTEM_COMMAND_NAMESPACE,
   SendTaskHeartbeatRequest,
 } from "@eventual/core/internal";
 import { HttpServiceClientProps } from "./base-http-client.js";
@@ -40,10 +39,7 @@ export class HttpEventualClient implements EventualServiceClient {
   protected readonly serviceClient: ServiceClient<EventualService>;
 
   constructor(props: HttpServiceClientProps) {
-    this.serviceClient = new ServiceClient<EventualService>(
-      props,
-      EVENTUAL_SYSTEM_COMMAND_NAMESPACE
-    );
+    this.serviceClient = new ServiceClient<EventualService>(props, "_system");
   }
 
   public async listWorkflows(): Promise<ListWorkflowsResponse> {


### PR DESCRIPTION
Removes the async_hooks module from the import path of the client

It is a trade off. Hard code `"_system"` value in the client to remove the dependency.

This is acceptable because the client needs to be usable everywhere and this value cannot change without breaking infrastructure. 