### PR TITLE
feat: create cdk with esm

### DIFF
--- a/packages/create-eventual/src/create-new-aws-cdk-project.ts
+++ b/packages/create-eventual/src/create-new-aws-cdk-project.ts
@@ -274,8 +274,9 @@ packages:
         compilerOptions: {
           outDir: "lib",
           rootDir: "src",
-          module: "CommonJS",
-          moduleResolution: "Node",
+          module: "esnext",
+          target: "ESNext",
+          moduleResolution: "NodeNext",
         },
         references: [
           {
@@ -286,6 +287,7 @@ packages:
       writeJsonFile("package.json", {
         name: infraPkgName,
         version: "0.0.0",
+        type: "module",
         scripts: {
           synth: "cdk synth",
           deploy: "cdk deploy",
@@ -310,14 +312,17 @@ packages:
         },
       }),
       writeJsonFile("cdk.json", {
-        app: "ts-node ./src/app.ts",
+        app: "ts-node-esm ./src/app.mts",
       }),
 
       fs
         .mkdir("src")
         .then(() =>
           Promise.all([
-            fs.writeFile(path.join("src", "app.ts"), sampleCDKApp(serviceName)),
+            fs.writeFile(
+              path.join("src", "app.mts"),
+              sampleCDKApp(serviceName)
+            ),
           ])
         ),
     ]);

--- a/packages/create-eventual/src/sample-code.ts
+++ b/packages/create-eventual/src/sample-code.ts
@@ -59,6 +59,9 @@ export function sampleCDKApp(serviceName: string) {
 
   return `import { App, Stack, CfnOutput } from "aws-cdk-lib";
 import { Service } from "@eventual/aws-cdk";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
 
 const app = new App();
 const stack = new Stack(app, "${serviceName}")


### PR DESCRIPTION
Worked locally

```ts
$ ts-node ./eventual/packages/create-eventual/bin/index.js 
$ pnpm eventual local --offline --port 3112
✔ Eventual Dev Server running on http://localhost:3112
$ cat infra/src/app.mts 
import { App, Stack, CfnOutput } from "aws-cdk-lib";
import { Service } from "@eventual/aws-cdk";
import { createRequire } from "module";

const require = createRequire(import.meta.url);

const app = new App();
const stack = new Stack(app, "eventual-esm")

import type * as eventualesm from "@eventual-esm/service"

const service = new Service<typeof eventualesm>(stack, "Service", {
  name: "eventual-esm",
  entry: require.resolve("@eventual-esm/service")
});
```