### PR TITLE
chore: rename entity.set to entity.put

### DIFF
--- a/packages/@eventual/aws-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/aws-runtime/src/stores/entity-store.ts
@@ -23,7 +23,7 @@ import {
   EntityQueryResult,
   EntityReadOptions,
   EntityScanOptions,
-  EntitySetOptions,
+  EntityPutOptions,
   EntityWithMetadata,
   KeyValue,
   TransactionCancelled,
@@ -121,11 +121,11 @@ export class AWSEntityStore extends EntityStore {
     };
   }
 
-  public override async _set(
+  public override async _put(
     entity: Entity,
     value: Attributes,
     key: NormalizedEntityCompositeKeyComplete,
-    options?: EntitySetOptions
+    options?: EntityPutOptions
   ): Promise<{ version: number }> {
     try {
       const result = await this.props.dynamo.send(
@@ -318,7 +318,7 @@ export class AWSEntityStore extends EntityStore {
       await this.props.dynamo.send(
         new TransactWriteItemsCommand({
           TransactItems: items.map((item): TransactWriteItem => {
-            return item.operation === "set"
+            return item.operation === "put"
               ? {
                   Update: this.createSetRequest(
                     item.entity,
@@ -393,7 +393,7 @@ export class AWSEntityStore extends EntityStore {
     entity: Entity,
     value: Attr,
     key: NormalizedEntityCompositeKey,
-    options?: EntitySetOptions
+    options?: EntityPutOptions
   ): Update {
     const indexGeneratedAttributes = computeGeneratedIndexKeyAttributes(
       entity,

--- a/packages/@eventual/cli/src/display/event.ts
+++ b/packages/@eventual/cli/src/display/event.ts
@@ -67,12 +67,12 @@ function displayEntityCommand(operation: EntityOperation) {
       const [key] = operation.params;
       output.push(`Key: ${JSON.stringify(key)}`);
     }
-    if (isEntityOperationOfType("set", operation)) {
+    if (isEntityOperationOfType("put", operation)) {
       const [value] = operation.params;
       output.push(`Entity: ${JSON.stringify(value)}`);
     }
     if (
-      isEntityOperationOfType("set", operation) ||
+      isEntityOperationOfType("put", operation) ||
       isEntityOperationOfType("delete", operation)
     ) {
       const [, options] = operation.params;
@@ -97,9 +97,9 @@ function displayEntityCommand(operation: EntityOperation) {
 function displayEntityTransactItem(item: EntityTransactItem): string[] {
   const entityName =
     typeof item.entity === "string" ? item.entity : item.entity.name;
-  if (item.operation === "set") {
+  if (item.operation === "put") {
     return displayEntityCommand({
-      operation: "set",
+      operation: "put",
       entityName,
       params: [item.value, item.options],
     });

--- a/packages/@eventual/core-runtime/src/local/stores/entity-store.ts
+++ b/packages/@eventual/core-runtime/src/local/stores/entity-store.ts
@@ -6,7 +6,7 @@ import {
   EntityQueryOptions,
   EntityQueryResult,
   EntityScanOptions,
-  EntitySetOptions,
+  EntityPutOptions,
   EntityStreamItem,
   EntityWithMetadata,
   KeyValue,
@@ -70,11 +70,11 @@ export class LocalEntityStore extends EntityStore {
     return this.getPartitionMap(entity, key.partition).get(skOrDefault(key));
   }
 
-  protected override async _set(
+  protected override async _put(
     entity: Entity,
     value: Attributes,
     key: NormalizedEntityCompositeKeyComplete,
-    options?: EntitySetOptions
+    options?: EntityPutOptions
   ): Promise<{ version: number }> {
     const { version = 0, value: oldValue } =
       (await this._getWithMetadata(entity, key)) ?? {};
@@ -281,8 +281,8 @@ export class LocalEntityStore extends EntityStore {
      */
     await Promise.all(
       items.map(async (item) => {
-        if (item.operation === "set") {
-          return await this._set(
+        if (item.operation === "put") {
+          return await this._put(
             item.entity,
             item.value,
             item.key,

--- a/packages/@eventual/core-runtime/src/stores/entity-store.ts
+++ b/packages/@eventual/core-runtime/src/stores/entity-store.ts
@@ -10,7 +10,7 @@ import {
   EntityQueryResult,
   EntityReadOptions,
   EntityScanOptions,
-  EntitySetOptions,
+  EntityPutOptions,
   EntityTransactItem,
   EntityWithMetadata,
   KeyMap,
@@ -62,10 +62,10 @@ export abstract class EntityStore implements EntityHook {
     options?: EntityReadOptions
   ): Promise<EntityWithMetadata | undefined>;
 
-  public set(
+  public put(
     entityName: string,
     value: Attributes,
-    options?: EntitySetOptions
+    options?: EntityPutOptions
   ): Promise<{ version: number }> {
     const entity = this.getEntity(entityName);
     const normalizedKey = normalizeCompositeKey(entity, value);
@@ -74,14 +74,14 @@ export abstract class EntityStore implements EntityHook {
       throw new Error("Key cannot be partial for set.");
     }
 
-    return this._set(entity, value, normalizedKey, options);
+    return this._put(entity, value, normalizedKey, options);
   }
 
-  protected abstract _set(
+  protected abstract _put(
     entity: Entity,
     value: Attributes,
     key: NormalizedEntityCompositeKeyComplete,
-    options?: EntitySetOptions
+    options?: EntityPutOptions
   ): Promise<{ version: number }>;
 
   public delete(
@@ -196,7 +196,7 @@ export abstract class EntityStore implements EntityHook {
           typeof item.entity === "string"
             ? this.getEntity(item.entity)
             : item.entity;
-        const keyValue = item.operation === "set" ? item.value : item.key;
+        const keyValue = item.operation === "put" ? item.value : item.key;
         const key = normalizeCompositeKey(entity, keyValue);
         if (!isCompleteKey(key)) {
           throw new Error(
@@ -204,9 +204,9 @@ export abstract class EntityStore implements EntityHook {
           );
         }
 
-        return item.operation === "set"
+        return item.operation === "put"
           ? {
-              operation: "set",
+              operation: "put",
               entity,
               key,
               value: item.value,
@@ -248,9 +248,9 @@ export type NormalizedEntityTransactItem = {
   key: NormalizedEntityCompositeKeyComplete;
 } & (
   | {
-      operation: "set";
+      operation: "put";
       value: Attributes;
-      options?: EntitySetOptions;
+      options?: EntityPutOptions;
     }
   | {
       operation: "delete";

--- a/packages/@eventual/core-runtime/test/command-executor.test.ts
+++ b/packages/@eventual/core-runtime/test/command-executor.test.ts
@@ -63,7 +63,7 @@ const mockExecutionQueueClient = {
 const mockEntityStore = {
   get: jest.fn() as EntityStore["get"],
   getWithMetadata: jest.fn() as EntityStore["getWithMetadata"],
-  set: jest.fn() as EntityStore["set"],
+  put: jest.fn() as EntityStore["put"],
   delete: jest.fn() as EntityStore["delete"],
   query: jest.fn() as EntityStore["query"],
 } satisfies Partial<EntityStore> as EntityStore;
@@ -289,14 +289,14 @@ describe("entity request", () => {
     });
   });
 
-  test("set", async () => {
+  test("put", async () => {
     const event = await testExecutor.executeCall(
       workflow,
       executionId,
       entityRequestCall(
         {
           entityName: "ent",
-          operation: "set",
+          operation: "put",
           params: [{ key: "key", value: "some value" }],
         },
         0
@@ -304,7 +304,7 @@ describe("entity request", () => {
       baseTime
     );
 
-    expect(mockEntityStore.set).toHaveBeenCalledWith("ent", {
+    expect(mockEntityStore.put).toHaveBeenCalledWith("ent", {
       key: "key",
       value: "some value",
     });
@@ -314,7 +314,7 @@ describe("entity request", () => {
       type: WorkflowEventType.EntityRequest,
       operation: {
         entityName: "ent",
-        operation: "set",
+        operation: "put",
         params: [{ key: "key", value: "some value" }],
       },
       timestamp: expect.stringContaining("Z"),

--- a/packages/@eventual/core/test/infer.test.ts
+++ b/packages/@eventual/core/test/infer.test.ts
@@ -18,7 +18,7 @@ test("Person", () => {
 
   function noop() {
     // 'optional' should maintain '?' modifier
-    Person.set({
+    Person.put({
       name: "John",
     });
   }


### PR DESCRIPTION
Closes #404

BREAKING CHANGE: `entity.set` is now `entity.put`. All reference to set, for example in transaction operations and types, are also now "put".