### PR TITLE
feat: support api cdk overrides

### DIFF
--- a/packages/@eventual/aws-cdk/src/command-service.ts
+++ b/packages/@eventual/aws-cdk/src/command-service.ts
@@ -27,7 +27,7 @@ import { Arn, Duration, Lazy, Stack } from "aws-cdk-lib/core";
 import { Construct } from "constructs";
 import type openapi from "openapi3-ts";
 import { ApiDefinition } from "./constructs/http-api-definition.js";
-import { SpecHttpApi } from "./constructs/spec-http-api";
+import { SpecHttpApi, SpecHttpApiProps } from "./constructs/spec-http-api";
 import type { EventService } from "./event-service";
 import { grant } from "./grant";
 import { EventualResource } from "./resource.js";
@@ -40,6 +40,8 @@ import { ServiceFunction } from "./service-function.js";
 import type { TaskService } from "./task-service";
 import { ServiceEntityProps, serviceFunctionArn } from "./utils";
 import type { WorkflowService } from "./workflow-service";
+
+export type ApiOverrides = Omit<SpecHttpApiProps, "apiDefinition">;
 
 export type Commands<Service> = {
   default: EventualResource;
@@ -93,6 +95,7 @@ export interface CommandsProps<Service = any>
     info: openapi.InfoObject;
   };
   overrides?: CommandProps<Service>;
+  apiOverrides?: ApiOverrides;
   taskService: TaskService<Service>;
   workflowService: WorkflowService;
 }
@@ -201,6 +204,7 @@ export class CommandService<Service = any> {
     // Service => Gateway
     this.gateway = new SpecHttpApi(props.serviceScope, "Gateway", {
       apiDefinition: ApiDefinition.fromInline(this.specification),
+      ...props.apiOverrides,
     });
 
     this.gateway.node.addDependency(this.integrationRole);

--- a/packages/@eventual/aws-cdk/src/constructs/spec-http-api.ts
+++ b/packages/@eventual/aws-cdk/src/constructs/spec-http-api.ts
@@ -81,7 +81,6 @@ export class SpecHttpApi extends HttpApiBase {
     props.apiDefinition.bindAfterCreate(this, this);
 
     const resource = new CfnApi(this, "Resource", {
-      name: props.apiName,
       body: apiDefConfig.inlineDefinition ?? undefined,
       bodyS3Location: apiDefConfig.inlineDefinition
         ? undefined
@@ -120,7 +119,12 @@ export class SpecHttpApi extends HttpApiBase {
 
 export type SpecHttpApiProps = Omit<
   HttpApiProps,
-  "corsPreflight" | "description"
+  | "corsPreflight"
+  | "description"
+  | "apiName"
+  | "defaultIntegration"
+  | "defaultAuthorizer"
+  | "defaultAuthorizationScopes"
 > & {
   /**
    * An OpenAPI definition compatible with API Gateway.

--- a/packages/@eventual/aws-cdk/src/service.ts
+++ b/packages/@eventual/aws-cdk/src/service.ts
@@ -38,6 +38,7 @@ import {
 } from "./bucket-service";
 import { BuildOutput, buildServiceSync } from "./build";
 import {
+  ApiOverrides,
   CommandProps,
   CommandService,
   Commands,
@@ -150,6 +151,7 @@ export interface ServiceProps<Service = any> {
    * Keep in mind that the output must be valid for APIGateway.
    */
   openApi?: CommandsProps<Service>["openApi"];
+  api?: ApiOverrides;
   /**
    * Customize the configuration of the OpenSearch clusters and each of the OpenSearch Indices.
    */
@@ -429,6 +431,7 @@ export class Service<S = any> extends Construct {
       cors: props.cors,
       local: this.local,
       openApi,
+      apiOverrides: props.api,
       ...workerConstructProps,
     });
     proxyCommandService._bind(this.commandService);


### PR DESCRIPTION
Requested by @mattduran420. Support a few overrides for api gateway, for example, adding a custom domain in CDK.

![image](https://github.com/functionless/eventual/assets/289213/7df96cb5-03c7-476f-932a-82176a704102)