### PR TITLE
fix: service without open search throws errors

### DIFF
--- a/packages/@eventual/aws-runtime/src/create.ts
+++ b/packages/@eventual/aws-runtime/src/create.ts
@@ -37,6 +37,7 @@ import { AWSExecutionStore } from "./stores/execution-store.js";
 import { AWSTaskStore } from "./stores/task-store.js";
 import { AWSOpenSearchClient } from "./clients/opensearch-client.js";
 import { defaultProvider } from "@aws-sdk/credential-provider-node";
+import { ServiceSpec } from "@eventual/core/internal";
 
 /**
  * Client creators to be used by the lambda functions.
@@ -285,16 +286,22 @@ export const createHttpServiceClient = /* @__PURE__ */ memoize(
     new AWSHttpEventualClient({ serviceUrl: serviceUrl ?? env.serviceUrl() })
 );
 
-export const createOpenSearchClient = /* @__PURE__ */ memoize(async () => {
-  const credentials = await defaultProvider()();
-  const region = env.awsRegion();
+export const createOpenSearchClient = /* @__PURE__ */ memoize(
+  async (serviceSpec?: ServiceSpec) => {
+    if (serviceSpec?.search.indices.length === 0) {
+      return undefined;
+    } else {
+      const credentials = await defaultProvider()();
+      const region = env.awsRegion();
 
-  return new AWSOpenSearchClient({
-    credentials,
-    region,
-    node: env.openSearchEndpoint(),
-  });
-});
+      return new AWSOpenSearchClient({
+        credentials,
+        region,
+        node: env.openSearchEndpoint(),
+      });
+    }
+  }
+);
 
 function memoize<T extends (...args: any[]) => any>(
   fn: T,

--- a/packages/@eventual/aws-runtime/src/handlers/bucket-handler-worker.ts
+++ b/packages/@eventual/aws-runtime/src/handlers/bucket-handler-worker.ts
@@ -24,7 +24,7 @@ import {
 const worker = createBucketNotificationHandlerWorker({
   bucketStore: createBucketStore(),
   entityStore: createEntityStore(),
-  openSearchClient: await createOpenSearchClient(),
+  openSearchClient: await createOpenSearchClient(serviceSpec),
   serviceClient: createServiceClient({}),
   serviceName,
   serviceSpec,

--- a/packages/@eventual/aws-runtime/src/handlers/command-worker.ts
+++ b/packages/@eventual/aws-runtime/src/handlers/command-worker.ts
@@ -21,7 +21,7 @@ import { createApiGCommandWorker } from "./apig-command-worker.js";
 export default createApiGCommandWorker({
   bucketStore: createBucketStore(),
   entityStore: createEntityStore(),
-  openSearchClient: await createOpenSearchClient(),
+  openSearchClient: await createOpenSearchClient(serviceSpec),
   // the service client, spec, and service url will be created at runtime, using a computed uri from the apigateway request
   // pulls the service url from the request instead of env variables to reduce the circular dependency between commands and the gateway.
   serviceClientBuilder: (serviceUrl) =>

--- a/packages/@eventual/aws-runtime/src/handlers/entity-stream-worker.ts
+++ b/packages/@eventual/aws-runtime/src/handlers/entity-stream-worker.ts
@@ -33,7 +33,7 @@ const entityProvider = new GlobalEntityProvider();
 const worker = createEntityStreamWorker({
   bucketStore: createBucketStore(),
   entityStore: createEntityStore(),
-  openSearchClient: await createOpenSearchClient(),
+  openSearchClient: await createOpenSearchClient(serviceSpec),
   serviceClient: createServiceClient({}),
   serviceSpec,
   serviceName,

--- a/packages/@eventual/aws-runtime/src/handlers/orchestrator.ts
+++ b/packages/@eventual/aws-runtime/src/handlers/orchestrator.ts
@@ -1,3 +1,4 @@
+import serviceSpec from "@eventual/injected/spec";
 import "@eventual/injected/entry";
 
 import {
@@ -42,7 +43,7 @@ const orchestrate = createOrchestrator({
     entityStore: createEntityStore(),
     eventClient: createEventClient(),
     executionQueueClient: createExecutionQueueClient(),
-    openSearchClient: await createOpenSearchClient(),
+    openSearchClient: await createOpenSearchClient(serviceSpec),
     taskClient: createTaskClient(),
     timerClient: createTimerClient(),
     transactionClient: createTransactionClient(),

--- a/packages/@eventual/aws-runtime/src/handlers/subscription-worker.ts
+++ b/packages/@eventual/aws-runtime/src/handlers/subscription-worker.ts
@@ -19,7 +19,7 @@ import { serviceName, serviceUrl } from "../env.js";
 export const processEvent = createSubscriptionWorker({
   bucketStore: createBucketStore(),
   entityStore: createEntityStore(),
-  openSearchClient: await createOpenSearchClient(),
+  openSearchClient: await createOpenSearchClient(serviceSpec),
   // partially uses the runtime clients and partially uses the http client
   serviceClient: createServiceClient({
     eventClient: createEventClient(),

--- a/packages/@eventual/aws-runtime/src/handlers/task-worker.ts
+++ b/packages/@eventual/aws-runtime/src/handlers/task-worker.ts
@@ -29,7 +29,7 @@ const worker = createTaskWorker({
   bucketStore: createBucketStore(),
   entityStore: createEntityStore(),
   eventClient: createEventClient(),
-  openSearchClient: await createOpenSearchClient(),
+  openSearchClient: await createOpenSearchClient(serviceSpec),
   executionQueueClient: createExecutionQueueClient(),
   logAgent: createLogAgent(),
   metricsClient: AWSMetricsClient,

--- a/packages/@eventual/core-runtime/src/workflow/call-executor.ts
+++ b/packages/@eventual/core-runtime/src/workflow/call-executor.ts
@@ -31,7 +31,7 @@ interface WorkflowCallExecutorDependencies {
   bucketStore: BucketStore;
   entityStore: EntityStore;
   eventClient: EventClient;
-  openSearchClient: OpenSearchClient;
+  openSearchClient?: OpenSearchClient;
   executionQueueClient: ExecutionQueueClient;
   taskClient: TaskClient;
   timerClient: TimerClient;
@@ -69,10 +69,12 @@ export function createDefaultWorkflowCallExecutor(
       deps.executionQueueClient
     ),
     SignalHandlerCall: noOpExecutor, // signal handlers do not generate events
-    SearchCall: createSearchWorkflowQueueExecutor(
-      deps.openSearchClient,
-      deps.executionQueueClient
-    ),
+    SearchCall: deps.openSearchClient
+      ? createSearchWorkflowQueueExecutor(
+          deps.openSearchClient,
+          deps.executionQueueClient
+        )
+      : unsupportedExecutor,
     SendSignalCall: new SendSignalWorkflowCallExecutor(
       deps.executionQueueClient
     ),


### PR DESCRIPTION
Found by @mattduran420

When a service did not have an open search index, commands, workflows and more would fail. Use the service spec to determine if the client needs to be created or now (presence of an index) which matches the logic to create the infra in CDK.

Ran the runtime tests without open search and proved that all workflows and commands did stop working.

After this change, tests pass without and without open search.

```
{
    "errorType": "Error",
    "errorMessage": "Expected env variable EVENTUAL_OPENSEARCH_ENDPOINT to be present.",
    "stack": [
        "Error: Expected env variable EVENTUAL_OPENSEARCH_ENDPOINT to be present.",
        "    at assertNonNull (/packages/@eventual/core/src/internal/util.ts:9:11)",
        "    at tryGetEnv (/packages/@eventual/aws-runtime/src/env.ts:32:10)",
        "    at openSearchEndpoint (/packages/@eventual/aws-runtime/src/env.ts:41:3)",
        "    at <anonymous> (/packages/@eventual/aws-runtime/src/create.ts:295:15)",
        "    at <anonymous> (/packages/@eventual/aws-runtime/src/handlers/orchestrator.ts:45:23)"
    ]
}
```

Note: Ideally we'd also be able to remove the OpenSearch deps from the tree, but this is a good start.