### PR TITLE
feat: real promises in workflows

### DIFF
--- a/packages/@eventual/core-runtime/src/handlers/worker.ts
+++ b/packages/@eventual/core-runtime/src/handlers/worker.ts
@@ -127,6 +127,8 @@ export function createEventualWorker<Input extends any[], Output>(
         // directly calling a task does not work outside of a workflow
         TaskCall: unsupportedExecutor,
         TaskRequestCall: serviceClientExecutor,
+        // Passthrough?
+        PromiseCall: unsupportedExecutor,
         ...resolvedExecutorOverrides,
       }),
       new AllPropertyRetriever({

--- a/packages/@eventual/core-runtime/src/workflow/call-eventual-factory.ts
+++ b/packages/@eventual/core-runtime/src/workflow/call-eventual-factory.ts
@@ -75,6 +75,7 @@ export function createDefaultEventualFactory(): AllWorkflowEventualFactory {
     ExpectSignalCall: new ExpectSignalFactory(),
     GetExecutionCall: unsupportedFactory,
     InvokeTransactionCall: new TransactionCallEventualFactory(),
+    PromiseCall: unsupportedFactory, // promise is handled within the workflow
     SignalHandlerCall: new RegisterSignalHandlerCallFactory(),
     SearchCall: new SearchCallEventualFactory(),
     SendSignalCall: new SendSignalEventualFactory(),

--- a/packages/@eventual/core-runtime/src/workflow/call-executor.ts
+++ b/packages/@eventual/core-runtime/src/workflow/call-executor.ts
@@ -78,6 +78,7 @@ export function createDefaultWorkflowCallExecutor(
     SendSignalCall: new SendSignalWorkflowCallExecutor(
       deps.executionQueueClient
     ),
+    PromiseCall: noOpExecutor, // promises do not generate events
     TaskCall: new TaskCallWorkflowExecutor(deps.taskClient),
     TaskRequestCall: unsupportedExecutor, // TODO: add support for task heartbeat, success, and failure to the workflow
     ChildWorkflowCall: workflowClientExecutor,

--- a/packages/@eventual/core/src/internal/calls.ts
+++ b/packages/@eventual/core/src/internal/calls.ts
@@ -23,6 +23,7 @@ export type Call =
   | ExpectSignalCall
   | GetExecutionCall
   | InvokeTransactionCall
+  | PromiseCall
   | SignalHandlerCall
   | SearchCall
   | SendSignalCall
@@ -46,6 +47,7 @@ export enum CallKind {
   TaskRequestCall = 12,
   SearchCall = 11,
   StartWorkflowCall = 13,
+  PromiseCall = 15,
 }
 
 export const CallSymbol = /* @__PURE__ */ Symbol.for("eventual:EventualCall");
@@ -381,4 +383,13 @@ export interface InvokeTransactionCall<Input = any>
   extends CallBase<CallKind.InvokeTransactionCall, any> {
   input: Input;
   transactionName: string;
+}
+
+export function isPromiseCall(a: any): a is PromiseCall {
+  return isCallOfKind(CallKind.PromiseCall, a);
+}
+
+export interface PromiseCall<T = any>
+  extends CallBase<CallKind.PromiseCall, T> {
+  promise: Promise<T>;
 }


### PR DESCRIPTION
Prototype of a call that allows for real promises in workflow. Leaving it here to not lose it.

For example, allows running `import` directly from a workflow. Which is not advised, but with this change, technically possible.

> not advised

Because `import` could be non-deterministic.