### PR TITLE
feat: build aws-cdk as ESM and CJS and support ESM modules in infer

### DIFF
--- a/apps/test-app/tsconfig.json
+++ b/apps/test-app/tsconfig.json
@@ -7,7 +7,7 @@
     "rootDir": "src"
   },
   "references": [
-    { "path": "../../packages/@eventual/aws-cdk" },
+    { "path": "../../packages/@eventual/aws-cdk/tsconfig.cjs.json" },
     { "path": "../test-app-runtime" }
   ]
 }

--- a/packages/@eventual/aws-cdk/package.json
+++ b/packages/@eventual/aws-cdk/package.json
@@ -1,10 +1,20 @@
 {
   "name": "@eventual/aws-cdk",
   "version": "0.50.0",
-  "main": "lib/index.js",
-  "types:": "lib/index.d.ts",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "types:": "lib/esm/index.d.ts",
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "test": "jest --passWithNoTests"
+  },
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   },
   "dependencies": {
     "@aws-sdk/credential-provider-node": "^3.341.0",

--- a/packages/@eventual/aws-cdk/src/bucket-service.ts
+++ b/packages/@eventual/aws-cdk/src/bucket-service.ts
@@ -15,14 +15,18 @@ import { S3EventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import { Duration, RemovalPolicy, Stack } from "aws-cdk-lib/core";
 import { Construct } from "constructs";
-import type { CorsOptions } from "./command-service";
+import type { CorsOptions } from "./command-service.js";
 import {
   configureWorkerCalls,
   WorkerServiceConstructProps,
-} from "./service-common";
-import { ServiceFunction } from "./service-function";
-import { formatBucketArn, serviceBucketArn, ServiceEntityProps } from "./utils";
-import { EventualResource } from "./resource";
+} from "./service-common.js";
+import { ServiceFunction } from "./service-function.js";
+import {
+  formatBucketArn,
+  serviceBucketArn,
+  ServiceEntityProps,
+} from "./utils.js";
+import { EventualResource } from "./resource.js";
 
 export type BucketOverrides<Service> = Partial<
   ServiceEntityProps<

--- a/packages/@eventual/aws-cdk/src/build-cli.ts
+++ b/packages/@eventual/aws-cdk/src/build-cli.ts
@@ -1,4 +1,4 @@
-import { buildService, BuildAWSRuntimeProps } from "./build";
+import { buildService, BuildAWSRuntimeProps } from "./build.js";
 
 export async function main() {
   try {

--- a/packages/@eventual/aws-cdk/src/command-service.ts
+++ b/packages/@eventual/aws-cdk/src/command-service.ts
@@ -27,19 +27,19 @@ import { Arn, Duration, Lazy, Stack } from "aws-cdk-lib/core";
 import { Construct } from "constructs";
 import type openapi from "openapi3-ts";
 import { ApiDefinition } from "./constructs/http-api-definition.js";
-import { SpecHttpApi, SpecHttpApiProps } from "./constructs/spec-http-api";
-import type { EventService } from "./event-service";
-import { grant } from "./grant";
+import { SpecHttpApi, SpecHttpApiProps } from "./constructs/spec-http-api.js";
+import type { EventService } from "./event-service.js";
+import { grant } from "./grant.js";
 import { EventualResource } from "./resource.js";
-import { ServiceLocal } from "./service";
+import { ServiceLocal } from "./service.js";
 import {
   WorkerServiceConstructProps,
   configureWorkerCalls,
 } from "./service-common.js";
 import { ServiceFunction } from "./service-function.js";
-import type { TaskService } from "./task-service";
-import { ServiceEntityProps, serviceFunctionArn } from "./utils";
-import type { WorkflowService } from "./workflow-service";
+import type { TaskService } from "./task-service.js";
+import { ServiceEntityProps, serviceFunctionArn } from "./utils.js";
+import type { WorkflowService } from "./workflow-service.js";
 
 export type ApiOverrides = Omit<SpecHttpApiProps, "apiDefinition">;
 

--- a/packages/@eventual/aws-cdk/src/constructs/spec-http-api.ts
+++ b/packages/@eventual/aws-cdk/src/constructs/spec-http-api.ts
@@ -6,11 +6,11 @@ import {
   VpcLink,
   VpcLinkProps,
 } from "@aws-cdk/aws-apigatewayv2-alpha";
-import { ApiBase } from "@aws-cdk/aws-apigatewayv2-alpha/lib/common/base";
+import { ApiBase } from "@aws-cdk/aws-apigatewayv2-alpha/lib/common/base.js";
 import { CfnApi } from "aws-cdk-lib/aws-apigatewayv2";
 import { Metric, MetricOptions } from "aws-cdk-lib/aws-cloudwatch";
 import { Construct } from "constructs";
-import { ApiDefinition } from "./http-api-definition";
+import { ApiDefinition } from "./http-api-definition.js";
 
 /**
  * Taken from (and modified) closed cdk PR:

--- a/packages/@eventual/aws-cdk/src/debug-dashboard.ts
+++ b/packages/@eventual/aws-cdk/src/debug-dashboard.ts
@@ -5,7 +5,7 @@ import {
 } from "@eventual/core-runtime";
 import { Dashboard, LogQueryWidget } from "aws-cdk-lib/aws-cloudwatch";
 import { Construct } from "constructs";
-import { Service } from "./service";
+import { Service } from "./service.js";
 import { Stack } from "aws-cdk-lib/core";
 
 export interface DebugDashboardProps {

--- a/packages/@eventual/aws-cdk/src/entity-service.ts
+++ b/packages/@eventual/aws-cdk/src/entity-service.ts
@@ -34,13 +34,13 @@ import { DynamoEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { Duration, RemovalPolicy, Stack } from "aws-cdk-lib/core";
 import { Construct } from "constructs";
 import { EventService } from "./event-service.js";
-import { LazyInterface } from "./proxy-construct";
+import { LazyInterface } from "./proxy-construct.js";
 import {
   configureWorkerCalls,
   WorkerServiceConstructProps,
-} from "./service-common";
-import { ServiceFunction } from "./service-function";
-import { ServiceEntityProps, serviceTableArn } from "./utils";
+} from "./service-common.js";
+import { ServiceFunction } from "./service-function.js";
+import { ServiceEntityProps, serviceTableArn } from "./utils.js";
 import { WorkflowService } from "./workflow-service.js";
 import { EventualResource } from "./resource.js";
 

--- a/packages/@eventual/aws-cdk/src/event-service.ts
+++ b/packages/@eventual/aws-cdk/src/event-service.ts
@@ -7,8 +7,8 @@ import { Function } from "aws-cdk-lib/aws-lambda";
 import { Lazy, Resource, Stack } from "aws-cdk-lib/core";
 import { Construct } from "constructs";
 import type { OpenAPIObject, SchemaObject } from "openapi3-ts";
-import { grant } from "./grant";
-import { ServiceConstructProps } from "./service-common";
+import { grant } from "./grant.js";
+import { ServiceConstructProps } from "./service-common.js";
 
 export type EventsProps = ServiceConstructProps;
 

--- a/packages/@eventual/aws-cdk/src/package.json
+++ b/packages/@eventual/aws-cdk/src/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/@eventual/aws-cdk/src/proxy-construct.ts
+++ b/packages/@eventual/aws-cdk/src/proxy-construct.ts
@@ -1,4 +1,4 @@
-import { KeysOfType } from "./utils";
+import { KeysOfType } from "./utils.js";
 
 /**
  * A function which allows a one way interface to be lazily applied.

--- a/packages/@eventual/aws-cdk/src/resource.ts
+++ b/packages/@eventual/aws-cdk/src/resource.ts
@@ -1,7 +1,7 @@
 import { IGrantable, IPrincipal } from "aws-cdk-lib/aws-iam";
 import { Function } from "aws-cdk-lib/aws-lambda";
-import { DeepCompositePrincipal } from "./deep-composite-principal";
-import { ServiceLocal } from "./service";
+import { DeepCompositePrincipal } from "./deep-composite-principal.js";
+import { ServiceLocal } from "./service.js";
 
 export class EventualResource implements IGrantable {
   public grantPrincipal: IPrincipal;

--- a/packages/@eventual/aws-cdk/src/scheduler-service.ts
+++ b/packages/@eventual/aws-cdk/src/scheduler-service.ts
@@ -11,13 +11,13 @@ import { Function } from "aws-cdk-lib/aws-lambda";
 import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { IQueue, Queue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
-import { grant } from "./grant";
-import { LazyInterface } from "./proxy-construct";
-import { ServiceFunction } from "./service-function";
+import { grant } from "./grant.js";
+import { LazyInterface } from "./proxy-construct.js";
+import { ServiceFunction } from "./service-function.js";
 import type { TaskService } from "./task-service.js";
-import { serviceFunctionArn } from "./utils";
-import { WorkflowService } from "./workflow-service";
-import { ServiceConstructProps } from "./service-common";
+import { serviceFunctionArn } from "./utils.js";
+import { WorkflowService } from "./workflow-service.js";
+import { ServiceConstructProps } from "./service-common.js";
 
 export interface SchedulerProps extends ServiceConstructProps {
   /**

--- a/packages/@eventual/aws-cdk/src/search/base-search-service.ts
+++ b/packages/@eventual/aws-cdk/src/search/base-search-service.ts
@@ -4,14 +4,14 @@ import type { Function } from "aws-cdk-lib/aws-lambda";
 import * as aws_lambda from "aws-cdk-lib/aws-lambda";
 import { Duration, Lazy } from "aws-cdk-lib/core";
 import { Construct } from "constructs";
-import type { ServiceConstructProps } from "../service-common";
-import type { ServiceEntityProps } from "../utils";
-import { SearchIndex } from "./search-index";
+import type { ServiceConstructProps } from "../service-common.js";
+import type { ServiceEntityProps } from "../utils.js";
+import { SearchIndex } from "./search-index.js";
 import type {
   SearchPrincipal,
   SearchService,
   ServiceIndices,
-} from "./search-service";
+} from "./search-service.js";
 
 export type SearchIndexOverrides<Service> = ServiceEntityProps<
   Service,

--- a/packages/@eventual/aws-cdk/src/search/collection.ts
+++ b/packages/@eventual/aws-cdk/src/search/collection.ts
@@ -2,8 +2,8 @@ import * as aws_kms from "aws-cdk-lib/aws-kms";
 import * as aws_opensearchserverless from "aws-cdk-lib/aws-opensearchserverless";
 import { RemovalPolicy, Resource } from "aws-cdk-lib/core";
 import { Construct } from "constructs";
-import { Access, DataAccessPolicy } from "./data-access-policy";
-import { SearchPrincipal } from "./search-service";
+import { Access, DataAccessPolicy } from "./data-access-policy.js";
+import { SearchPrincipal } from "./search-service.js";
 
 export interface ICollection {
   readonly collectionName: string;

--- a/packages/@eventual/aws-cdk/src/search/data-access-policy.ts
+++ b/packages/@eventual/aws-cdk/src/search/data-access-policy.ts
@@ -1,7 +1,7 @@
 import aws_opensearchserverless from "aws-cdk-lib/aws-opensearchserverless";
 import { Lazy, Resource } from "aws-cdk-lib/core";
 import { Construct } from "constructs";
-import { Collection } from "./collection";
+import { Collection } from "./collection.js";
 
 export enum Access {
   /**

--- a/packages/@eventual/aws-cdk/src/search/search-index.ts
+++ b/packages/@eventual/aws-cdk/src/search/search-index.ts
@@ -2,7 +2,7 @@ import { IndexSpec } from "@eventual/core/internal";
 import type { opensearchtypes } from "@opensearch-project/opensearch";
 import { CustomResource, Resource } from "aws-cdk-lib/core";
 import { Construct } from "constructs";
-import type { SearchPrincipal, SearchService } from "./search-service";
+import type { SearchPrincipal, SearchService } from "./search-service.js";
 
 /**
  * Attributes exposed by the {@link SearchIndex} Resource.

--- a/packages/@eventual/aws-cdk/src/search/search-service.ts
+++ b/packages/@eventual/aws-cdk/src/search/search-service.ts
@@ -1,12 +1,12 @@
 import type aws_iam from "aws-cdk-lib/aws-iam";
 import type aws_lambda from "aws-cdk-lib/aws-lambda";
 import type { Function } from "aws-cdk-lib/aws-lambda";
-import type { ServiceConstructProps } from "../service-common";
-import type { ServiceEntityProps } from "../utils";
-import type { AccessOptions } from "./data-access-policy";
-import type { SearchIndex } from "./search-index";
-import type { ServerfulSearchServiceProps } from "./serverful-search-service";
-import type { ServerlessSearchServiceProps } from "./serverless-search-service";
+import type { ServiceConstructProps } from "../service-common.js";
+import type { ServiceEntityProps } from "../utils.js";
+import type { AccessOptions } from "./data-access-policy.js";
+import type { SearchIndex } from "./search-index.js";
+import type { ServerfulSearchServiceProps } from "./serverful-search-service.js";
+import type { ServerlessSearchServiceProps } from "./serverless-search-service.js";
 
 /**
  * Properties that override the configuration of the {@link SearchService} within

--- a/packages/@eventual/aws-cdk/src/search/serverful-search-service.ts
+++ b/packages/@eventual/aws-cdk/src/search/serverful-search-service.ts
@@ -4,13 +4,13 @@ import {
   EngineVersion,
 } from "aws-cdk-lib/aws-opensearchservice";
 import { RemovalPolicy } from "aws-cdk-lib/core";
-import { grant } from "../grant";
+import { grant } from "../grant.js";
 import {
   BaseSearchService,
   BaseSearchServiceProps,
-} from "./base-search-service";
-import type { SearchPrincipal } from "./search-service";
-import type { ServerlessSearchService } from "./serverless-search-service";
+} from "./base-search-service.js";
+import type { SearchPrincipal } from "./search-service.js";
+import type { ServerlessSearchService } from "./serverless-search-service.js";
 
 export interface ServerfulSearchServiceProps<Service>
   extends BaseSearchServiceProps<Service>,

--- a/packages/@eventual/aws-cdk/src/search/serverless-search-service.ts
+++ b/packages/@eventual/aws-cdk/src/search/serverless-search-service.ts
@@ -1,14 +1,14 @@
 import { sanitizeCollectionName } from "@eventual/aws-runtime";
 import type { IRole } from "aws-cdk-lib/aws-iam";
 import { RemovalPolicy } from "aws-cdk-lib/core";
-import { grant } from "../grant";
+import { grant } from "../grant.js";
 import {
   BaseSearchService,
   BaseSearchServiceProps,
-} from "./base-search-service";
-import { Collection, CollectionProps, CollectionType } from "./collection";
-import { SearchPrincipal } from "./search-service";
-import type { ServerfulSearchService } from "./serverful-search-service";
+} from "./base-search-service.js";
+import { Collection, CollectionProps, CollectionType } from "./collection.js";
+import { SearchPrincipal } from "./search-service.js";
+import type { ServerfulSearchService } from "./serverful-search-service.js";
 
 export interface ServerlessSearchServiceProps<Service>
   extends BaseSearchServiceProps<Service>,

--- a/packages/@eventual/aws-cdk/src/service-common.ts
+++ b/packages/@eventual/aws-cdk/src/service-common.ts
@@ -1,12 +1,12 @@
 import { Function } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
-import { BucketService } from "./bucket-service";
-import { BuildOutput } from "./build";
-import { CommandService } from "./command-service";
-import { EntityService } from "./entity-service";
-import { LazyInterface } from "./proxy-construct";
-import { SearchService } from "./search/search-service";
-import { Service } from "./service";
+import { BucketService } from "./bucket-service.js";
+import { BuildOutput } from "./build.js";
+import { CommandService } from "./command-service.js";
+import { EntityService } from "./entity-service.js";
+import { LazyInterface } from "./proxy-construct.js";
+import { SearchService } from "./search/search-service.js";
+import { Service } from "./service.js";
 
 export interface ServiceConstructProps {
   /**

--- a/packages/@eventual/aws-cdk/src/service-dashboard.ts
+++ b/packages/@eventual/aws-cdk/src/service-dashboard.ts
@@ -2,10 +2,10 @@ import {
   Dashboard,
   GraphWidget,
   MathExpression,
-  Statistic,
+  Stats,
 } from "aws-cdk-lib/aws-cloudwatch";
 import { Construct } from "constructs";
-import { Service } from "./service";
+import { Service } from "./service.js";
 import { Stack } from "aws-cdk-lib/core";
 
 export interface ServiceDashboardProps {
@@ -62,7 +62,7 @@ export class ServiceDashboard extends Construct {
                 expression: "max_age / 1000",
                 usingMetrics: {
                   max_age: service.metricMaxTaskAge({
-                    statistic: Statistic.MAXIMUM,
+                    statistic: Stats.MAXIMUM,
                   }),
                 },
                 label: "Maximum age of any Task processed by the Orchestrator",
@@ -95,7 +95,7 @@ export class ServiceDashboard extends Construct {
               }),
               service.metricSavedHistoryEvents({
                 label: "Maximum number of events in the History",
-                statistic: Statistic.MAXIMUM,
+                statistic: Stats.MAXIMUM,
               }),
             ],
             width: 12,
@@ -114,7 +114,7 @@ export class ServiceDashboard extends Construct {
               }),
               service.metricCommandsInvoked({
                 label: "Maximum number of Commands output by a Workflow step",
-                statistic: Statistic.MAXIMUM,
+                statistic: Stats.MAXIMUM,
               }),
             ],
             width: 12,

--- a/packages/@eventual/aws-cdk/src/service-function.ts
+++ b/packages/@eventual/aws-cdk/src/service-function.ts
@@ -7,8 +7,8 @@ import {
 import { Duration } from "aws-cdk-lib/core";
 import { Function, FunctionProps } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
-import type { BuildOutput } from "./build";
-import { baseFnProps } from "./utils";
+import type { BuildOutput } from "./build.js";
+import { baseFnProps } from "./utils.js";
 
 export interface ServiceFunctionProps {
   overrides?: Omit<Partial<FunctionProps>, "code" | "handler" | "functionName">;

--- a/packages/@eventual/aws-cdk/src/service.ts
+++ b/packages/@eventual/aws-cdk/src/service.ts
@@ -35,8 +35,8 @@ import {
   BucketService,
   ServiceBucketNotificationHandlers,
   ServiceBuckets,
-} from "./bucket-service";
-import { BuildOutput, buildServiceSync } from "./build";
+} from "./bucket-service.js";
+import { BuildOutput, buildServiceSync } from "./build.js";
 import {
   ApiOverrides,
   CommandProps,
@@ -44,7 +44,7 @@ import {
   Commands,
   CommandsProps,
   CorsOptions,
-} from "./command-service";
+} from "./command-service.js";
 import { DeepCompositePrincipal } from "./deep-composite-principal.js";
 import {
   EntityService,
@@ -54,30 +54,36 @@ import {
   ServiceEntities,
   ServiceEntityStreams,
 } from "./entity-service.js";
-import { EventService } from "./event-service";
-import { grant } from "./grant";
-import { lazyInterface } from "./proxy-construct";
-import { EventualResource } from "./resource";
-import { SchedulerService } from "./scheduler-service";
-import { SearchService, SearchServiceOverrides } from "./search/search-service";
-import { ServerfulSearchService } from "./search/serverful-search-service";
-import { ServerlessSearchService } from "./search/serverless-search-service";
+import { EventService } from "./event-service.js";
+import { grant } from "./grant.js";
+import { lazyInterface } from "./proxy-construct.js";
+import { EventualResource } from "./resource.js";
+import { SchedulerService } from "./scheduler-service.js";
+import {
+  SearchService,
+  SearchServiceOverrides,
+} from "./search/search-service.js";
+import { ServerfulSearchService } from "./search/serverful-search-service.js";
+import { ServerlessSearchService } from "./search/serverless-search-service.js";
 import {
   ServiceConstructProps,
   WorkerServiceConstructProps,
-} from "./service-common";
+} from "./service-common.js";
 import {
   Subscription,
   SubscriptionOverrides,
   Subscriptions,
-} from "./subscriptions";
+} from "./subscriptions.js";
 import {
   ServiceTasks,
   Task,
   TaskOverrides,
   TaskService,
 } from "./task-service.js";
-import { WorkflowService, WorkflowServiceOverrides } from "./workflow-service";
+import {
+  WorkflowService,
+  WorkflowServiceOverrides,
+} from "./workflow-service.js";
 
 /**
  * The properties for subscribing a Service to another Service's events.

--- a/packages/@eventual/aws-cdk/src/subscriptions.ts
+++ b/packages/@eventual/aws-cdk/src/subscriptions.ts
@@ -6,17 +6,17 @@ import aws_iam from "aws-cdk-lib/aws-iam";
 import type { Function, FunctionProps } from "aws-cdk-lib/aws-lambda";
 import { Queue } from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
-import type { BuildOutput } from "./build";
-import { DeepCompositePrincipal } from "./deep-composite-principal";
-import type { EventService } from "./event-service";
-import type { ServiceLocal } from "./service";
+import type { BuildOutput } from "./build.js";
+import { DeepCompositePrincipal } from "./deep-composite-principal.js";
+import type { EventService } from "./event-service.js";
+import type { ServiceLocal } from "./service.js";
 import {
   WorkerServiceConstructProps,
   configureWorkerCalls,
-} from "./service-common";
-import { ServiceFunction } from "./service-function";
-import type { ServiceEntityProps } from "./utils";
-import { EventualResource } from "./resource";
+} from "./service-common.js";
+import { ServiceFunction } from "./service-function.js";
+import type { ServiceEntityProps } from "./utils.js";
+import { EventualResource } from "./resource.js";
 
 export type Subscriptions<Service> = ServiceEntityProps<
   Service,

--- a/packages/@eventual/aws-cdk/src/task-service.ts
+++ b/packages/@eventual/aws-cdk/src/task-service.ts
@@ -11,20 +11,20 @@ import { Function, FunctionProps } from "aws-cdk-lib/aws-lambda";
 import { LambdaDestination } from "aws-cdk-lib/aws-lambda-destinations";
 import { Duration, RemovalPolicy, Stack } from "aws-cdk-lib/core";
 import { Construct } from "constructs";
-import type { BuildOutput } from "./build";
-import { DeepCompositePrincipal } from "./deep-composite-principal";
-import { grant } from "./grant";
-import type { LazyInterface } from "./proxy-construct";
-import type { SchedulerService } from "./scheduler-service";
-import type { ServiceLocal } from "./service";
+import type { BuildOutput } from "./build.js";
+import { DeepCompositePrincipal } from "./deep-composite-principal.js";
+import { grant } from "./grant.js";
+import type { LazyInterface } from "./proxy-construct.js";
+import type { SchedulerService } from "./scheduler-service.js";
+import type { ServiceLocal } from "./service.js";
 import {
   WorkerServiceConstructProps,
   configureWorkerCalls,
-} from "./service-common";
-import { ServiceFunction } from "./service-function";
-import { ServiceEntityProps, serviceFunctionArn } from "./utils";
-import type { WorkflowService } from "./workflow-service";
-import { EventualResource } from "./resource";
+} from "./service-common.js";
+import { ServiceFunction } from "./service-function.js";
+import { ServiceEntityProps, serviceFunctionArn } from "./utils.js";
+import type { WorkflowService } from "./workflow-service.js";
+import { EventualResource } from "./resource.js";
 
 export type ServiceTasks<Service> = ServiceEntityProps<Service, "Task", Task>;
 

--- a/packages/@eventual/aws-cdk/src/workflow-service.ts
+++ b/packages/@eventual/aws-cdk/src/workflow-service.ts
@@ -22,19 +22,19 @@ import {
 } from "aws-cdk-lib/aws-sqs";
 import { RemovalPolicy } from "aws-cdk-lib/core";
 import { Construct } from "constructs";
-import { BucketService } from "./bucket-service";
+import { BucketService } from "./bucket-service.js";
 import {
   EventBridgePipe,
   PipeSourceParameters,
-} from "./constructs/event-bridge-pipe";
-import { EntityService } from "./entity-service";
-import { EventService } from "./event-service";
-import { grant } from "./grant";
-import { LazyInterface } from "./proxy-construct";
-import { SchedulerService } from "./scheduler-service";
-import type { SearchService } from "./search/search-service";
-import { ServiceConstructProps } from "./service-common";
-import { ServiceFunction } from "./service-function";
+} from "./constructs/event-bridge-pipe.js";
+import { EntityService } from "./entity-service.js";
+import { EventService } from "./event-service.js";
+import { grant } from "./grant.js";
+import { LazyInterface } from "./proxy-construct.js";
+import { SchedulerService } from "./scheduler-service.js";
+import type { SearchService } from "./search/search-service.js";
+import { ServiceConstructProps } from "./service-common.js";
+import { ServiceFunction } from "./service-function.js";
 import type { TaskService } from "./task-service.js";
 
 export interface WorkflowsProps extends ServiceConstructProps {

--- a/packages/@eventual/aws-cdk/tsconfig.cjs.json
+++ b/packages/@eventual/aws-cdk/tsconfig.cjs.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig-base.cjs",
+  "include": ["src"],
+  "exclude": ["lib", "node_modules"],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib/cjs",
+    "declaration": true,
+    "inlineSourceMap": true
+  },
+  "references": [
+    { "path": "../aws-runtime/tsconfig.cjs.json" },
+    { "path": "../core/tsconfig.cjs.json" },
+    { "path": "../compiler/tsconfig.cjs.json" },
+    { "path": "../core-runtime/tsconfig.cjs.json" },
+    { "path": "../project/tsconfig.cjs.json" }
+  ]
+}

--- a/packages/@eventual/aws-cdk/tsconfig.json
+++ b/packages/@eventual/aws-cdk/tsconfig.json
@@ -1,18 +1,18 @@
 {
-  "extends": "../../../tsconfig-base.cjs",
+  "extends": "../../../tsconfig-base",
   "include": ["src", "src/package.json"],
   "exclude": ["lib", "node_modules"],
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib",
+    "outDir": "lib/esm",
     "declaration": true,
     "inlineSourceMap": true
   },
   "references": [
-    { "path": "../aws-runtime/tsconfig.cjs.json" },
-    { "path": "../core/tsconfig.cjs.json" },
-    { "path": "../compiler/tsconfig.cjs.json" },
-    { "path": "../core-runtime/tsconfig.cjs.json" },
-    { "path": "../project/tsconfig.cjs.json" }
+    { "path": "../aws-runtime/tsconfig.json" },
+    { "path": "../core/tsconfig.json" },
+    { "path": "../compiler/tsconfig.json" },
+    { "path": "../core-runtime/tsconfig.json" },
+    { "path": "../project/tsconfig.json" }
   ]
 }

--- a/packages/@eventual/compiler/src/eventual-infer.ts
+++ b/packages/@eventual/compiler/src/eventual-infer.ts
@@ -54,6 +54,8 @@ export async function infer(
     bundle: true,
     write: false,
     platform: "node",
+    format: "esm",
+    target: "es2022",
   });
 
   const script = bundle.outputFiles[0]!.text;


### PR DESCRIPTION
We ran into a problem where we could not use top-level await or other ESM features because infer breaks. This change addresses that.

- [x] Build the @eventual/aws-cdk package with both ESM and CJS like we do all the others
- [x] Update esbuild to use format "esm" and target "es2022" 