### PR TITLE
fix: missing node constants export

### DIFF
--- a/packages/@eventual/core/package.json
+++ b/packages/@eventual/core/package.json
@@ -18,6 +18,7 @@
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "files": [
+    "constants",
     "internal",
     "lib"
   ],


### PR DESCRIPTION
Debugging typescript performance issues in another project.

Typescript started to pull in `../eventual/*` files from across my file system. This seems to be because `./constants/index.js` (`@eventual/core/contstants`) did not actually exist in `@eventual/core` because it wasn't included in the node `files`. 

My system seems to resolve it to my local, but I am unsure what it is doing on other systems. When the file is included from local, typescript started to pull other core files from my local eventual repo too (see below).

* Added `constants` to `files` in package.json to match the `internal` path.

(via `tsc --explainFiles`)

```
../eventual/packages/@eventual/core/lib/cjs/http/command-rpc-path.d.ts
  Imported via "./http/command-rpc-path.js" from file '../eventual/packages/@eventual/core/lib/cjs/constants.d.ts'
../eventual/packages/@eventual/core/lib/cjs/constants.d.ts
  Imported via "../lib/cjs/constants.js" from file '../eventual/packages/@eventual/core/constants/index.d.ts'
../eventual/packages/@eventual/core/constants/index.d.ts
  Imported via "@eventual/core/constants" from file 'node_modules/.pnpm/@eventual+client@0.50.4/node_modules/@eventual/client/lib/cjs/base-http-client.d.ts' with packageId '@eventual/core/constants/index.d.ts@0.50.3'
```