### PR TITLE
fix: local entity index query failed when index was missing from local data

### DIFF
--- a/packages/@eventual/core-runtime/test/local-bucket-store.test.ts
+++ b/packages/@eventual/core-runtime/test/local-bucket-store.test.ts
@@ -48,8 +48,6 @@ describe("persist", () => {
       )
     );
 
-    console.log(bucketStore.serialize());
-
     await expect(
       bucketStore.get("bucket", "key").then((v) => v?.getBodyString())
     ).resolves.toEqual("value");

--- a/packages/@eventual/core-runtime/test/local-entity-store.test.ts
+++ b/packages/@eventual/core-runtime/test/local-entity-store.test.ts
@@ -1,0 +1,102 @@
+import { EntityQueryResult, entity } from "@eventual/core";
+import { rm } from "fs/promises";
+import path from "path";
+import { z } from "zod";
+import { EntityProvider } from "../src/index.js";
+import { NoOpLocalEnvConnector } from "../src/local/local-container.js";
+import { LocalPersistanceStore } from "../src/local/local-persistance-store.js";
+import { LocalEntityStore } from "../src/local/stores/entity-store.js";
+
+const __dirname: string =
+  typeof global.__dirname === "string"
+    ? global.__dirname
+    : path.dirname(new URL(import.meta.url).pathname);
+
+const testEntity = entity("myEntity", {
+  attributes: { value: z.string() },
+  partition: ["value"],
+});
+const testIndex = testEntity.index("testIndex", { partition: ["value"] });
+
+describe("persist", () => {
+  const storagePath = path.join(__dirname, "./.test_store");
+  afterAll(async () => {
+    await rm(storagePath, { recursive: true, force: true });
+  });
+  const entityProvider: EntityProvider = {
+    getEntity() {
+      return testEntity;
+    },
+  };
+  test("save", async () => {
+    const localPersistance = new LocalPersistanceStore(storagePath);
+    const entityStore = localPersistance.register(
+      "entity",
+      (_data) =>
+        new LocalEntityStore({
+          entityProvider,
+          localConnector: NoOpLocalEnvConnector,
+        })
+    );
+
+    await entityStore.put(testEntity.name, { value: "1" });
+
+    localPersistance.save();
+  });
+  test("load", async () => {
+    const localPersistance = new LocalPersistanceStore(storagePath);
+    const entityStore = localPersistance.register("entity", (data) =>
+      LocalEntityStore.fromSerializedData(
+        { entityProvider, localConnector: NoOpLocalEnvConnector },
+        data
+      )
+    );
+
+    await expect(
+      entityStore.get(testEntity.name, { value: "1" })
+    ).resolves.toEqual({
+      value: "1",
+    });
+    await expect(
+      entityStore.scan(testEntity.name)
+    ).resolves.toEqual<EntityQueryResult>({
+      entries: [{ value: { value: "1" }, version: 1 }],
+    });
+    await expect(
+      entityStore.scanIndex(testEntity.name, testIndex.name)
+    ).resolves.toEqual<EntityQueryResult>({
+      entries: [{ value: { value: "1" }, version: 1 }],
+    });
+  });
+
+  test("load without index", async () => {
+    await rm(
+      `${storagePath}/entity/${testEntity.name}/index/${testIndex.name}`,
+      { recursive: true, force: true }
+    );
+    const localPersistance = new LocalPersistanceStore(storagePath);
+    const entityStore = localPersistance.register("entity", (data) =>
+      LocalEntityStore.fromSerializedData(
+        { entityProvider, localConnector: NoOpLocalEnvConnector },
+        data
+      )
+    );
+
+    await entityStore.put(testEntity.name, { value: "1" });
+    await expect(
+      entityStore.get(testEntity.name, { value: "1" })
+    ).resolves.toEqual({
+      value: "1",
+    });
+    await expect(
+      entityStore.scan(testEntity.name)
+    ).resolves.toEqual<EntityQueryResult>({
+      entries: [{ value: { value: "1" }, version: 2 }],
+    });
+    await expect(
+      entityStore.queryIndex(testEntity.name, testIndex.name, { value: "1" })
+    ).resolves.toEqual<EntityQueryResult>({
+      entries: [{ value: { value: "1" }, version: 2 }],
+    });
+  });
+});


### PR DESCRIPTION
If the .eventual/local folder was missing an index (new/deleted), `index.query` would fail on query. change the logic to create requested indices on demand if they were not originally loaded.

TODO: Compute missing local indices on load for existing data https://github.com/functionless/eventual/issues/464