### PR TITLE
feat: external function modules

### DIFF
--- a/packages/@eventual/aws-cdk/src/build.ts
+++ b/packages/@eventual/aws-cdk/src/build.ts
@@ -225,7 +225,13 @@ export async function buildService(request: BuildAWSRuntimeProps) {
     return await Promise.all(
       commandSpecs.map(async (spec) => {
         return {
-          entry: await bundleFile(spec, "command", "command-worker", spec.name),
+          entry: await bundleFile(
+            spec,
+            "command",
+            "command-worker",
+            spec.name,
+            spec.externalModules
+          ),
           spec,
         };
       })
@@ -240,7 +246,8 @@ export async function buildService(request: BuildAWSRuntimeProps) {
             spec,
             "subscription",
             "subscription-worker",
-            spec.name
+            spec.name,
+            spec.props?.externalModules
           ),
           spec,
         };
@@ -252,7 +259,13 @@ export async function buildService(request: BuildAWSRuntimeProps) {
     return await Promise.all(
       specs.map(async (spec) => {
         return {
-          entry: await bundleFile(spec, "task", "task-worker", spec.name),
+          entry: await bundleFile(
+            spec,
+            "task",
+            "task-worker",
+            spec.name,
+            spec.options?.externalModules
+          ),
           spec,
         };
       })
@@ -267,7 +280,8 @@ export async function buildService(request: BuildAWSRuntimeProps) {
             spec,
             "entity-streams",
             "entity-stream-worker",
-            spec.name
+            spec.name,
+            spec.options?.externalModules
           ),
           spec,
         };
@@ -283,7 +297,8 @@ export async function buildService(request: BuildAWSRuntimeProps) {
             spec,
             "bucket-handlers",
             "bucket-handler-worker",
-            spec.name
+            spec.name,
+            spec.options?.externalModules
           ),
           spec,
         };
@@ -297,7 +312,8 @@ export async function buildService(request: BuildAWSRuntimeProps) {
         spec.handler,
         "queue-handlers",
         "queue-handler-worker",
-        spec.name
+        spec.name,
+        spec.handler.options?.externalModules
       ),
       spec: spec.handler,
     };
@@ -307,7 +323,13 @@ export async function buildService(request: BuildAWSRuntimeProps) {
     return await Promise.all(
       specs.map(async (spec) => {
         return {
-          entry: await bundleFile(spec, "socket", "socket-worker", spec.name),
+          entry: await bundleFile(
+            spec,
+            "socket",
+            "socket-worker",
+            spec.name,
+            spec.externalModules
+          ),
           spec,
         };
       })
@@ -315,12 +337,20 @@ export async function buildService(request: BuildAWSRuntimeProps) {
   }
 
   async function bundleFile<
-    Spec extends CommandSpec | SubscriptionSpec | TaskSpec | QueueHandlerSpec
+    Spec extends
+      | CommandSpec
+      | SubscriptionSpec
+      | TaskSpec
+      | QueueHandlerSpec
+      | SocketSpec
+      | EntityStreamSpec
+      | BucketNotificationHandlerSpec
   >(
     spec: Spec,
     pathPrefix: string,
     entryPoint: (typeof WORKER_ENTRY_POINTS)[number],
-    name: string
+    name: string,
+    externalModules?: string[]
   ): Promise<string> {
     return spec.sourceLocation?.fileName
       ? // we know the source location of the command, so individually build it from that
@@ -333,6 +363,7 @@ export async function buildService(request: BuildAWSRuntimeProps) {
           exportName: spec.sourceLocation.exportName,
           injectedEntry: spec.sourceLocation.fileName,
           injectedServiceSpec: specPath,
+          external: externalModules,
         })
       : monolithFunctions[entryPoint];
   }

--- a/packages/@eventual/core/src/function-props.ts
+++ b/packages/@eventual/core/src/function-props.ts
@@ -14,3 +14,7 @@ export interface FunctionRuntimeProps {
    */
   handlerTimeout?: DurationSchedule;
 }
+
+export interface FunctionBundleProps {
+  externalModules?: string[];
+}

--- a/packages/@eventual/core/src/internal/service-spec.ts
+++ b/packages/@eventual/core/src/internal/service-spec.ts
@@ -7,7 +7,10 @@ import type {
   EntityCompositeKeyPart,
   StreamQueryKey,
 } from "../entity/key.js";
-import type { FunctionRuntimeProps } from "../function-props.js";
+import type {
+  FunctionBundleProps,
+  FunctionRuntimeProps,
+} from "../function-props.js";
 import type { HttpMethod } from "../http-method.js";
 import type { RestParams } from "../http/command.js";
 import type { DurationSchedule } from "../schedule.js";
@@ -106,7 +109,8 @@ export interface CommandSpec<
   Input = undefined,
   Path extends string | undefined = undefined,
   Method extends HttpMethod | undefined = undefined
-> extends FunctionRuntimeProps {
+> extends FunctionRuntimeProps,
+    FunctionBundleProps {
   name: Name;
   /**
    * Long description of the API, written to the description field of the generated open API spec.
@@ -190,7 +194,9 @@ export interface IndexSpec extends opensearchtypes.IndicesIndexState {
 
 export type BucketNotificationEventType = "put" | "copy" | "delete";
 
-export interface BucketNotificationHandlerOptions extends FunctionRuntimeProps {
+export interface BucketNotificationHandlerOptions
+  extends FunctionRuntimeProps,
+    FunctionBundleProps {
   /**
    * A list of operations to be send to the stream.
    *
@@ -231,7 +237,8 @@ export interface EntityStreamOptions<
     | undefined,
   Operations extends EntityStreamOperation[] = EntityStreamOperation[],
   IncludeOld extends boolean = false
-> extends FunctionRuntimeProps {
+> extends FunctionRuntimeProps,
+    FunctionBundleProps {
   /**
    * A list of operations to be send to the stream.
    *
@@ -295,7 +302,9 @@ export interface TransactionSpec<Name extends string = string> {
 /**
  * TODO: Support filter criteria.
  */
-export interface QueueHandlerOptions extends FunctionRuntimeProps {
+export interface QueueHandlerOptions
+  extends FunctionRuntimeProps,
+    FunctionBundleProps {
   /**
    * Max batch size.
    *
@@ -329,7 +338,8 @@ export interface QueueSpec<Name extends string = string> {
 }
 
 export interface SocketSpec<Name extends string = string>
-  extends FunctionRuntimeProps {
+  extends FunctionRuntimeProps,
+    FunctionBundleProps {
   name: Name;
   sourceLocation?: SourceLocation;
 }

--- a/packages/@eventual/core/src/subscription.ts
+++ b/packages/@eventual/core/src/subscription.ts
@@ -1,5 +1,8 @@
 import type { Event, EventPayload } from "./event.js";
-import type { FunctionRuntimeProps } from "./function-props.js";
+import type {
+  FunctionBundleProps,
+  FunctionRuntimeProps,
+} from "./function-props.js";
 import { registerEventualResource } from "./internal/resources.js";
 import { isSourceLocation, SourceLocation } from "./internal/service-spec.js";
 import { ServiceContext } from "./service.js";
@@ -22,7 +25,9 @@ export type SubscriptionHandler<E extends EventPayload> = (
 /**
  * Runtime Props for an Event Handler.
  */
-export interface SubscriptionRuntimeProps extends FunctionRuntimeProps {
+export interface SubscriptionRuntimeProps
+  extends FunctionRuntimeProps,
+    FunctionBundleProps {
   /**
    * Number of times an event can be re-driven to the Event Handler before considering
    * the Event as failed to process and sending it to the Service Dead Letter Queue.

--- a/packages/@eventual/core/src/task.ts
+++ b/packages/@eventual/core/src/task.ts
@@ -1,6 +1,9 @@
 import { duration, time } from "./await-time.js";
 import type { ExecutionID } from "./execution.js";
-import type { FunctionRuntimeProps } from "./function-props.js";
+import type {
+  FunctionBundleProps,
+  FunctionRuntimeProps,
+} from "./function-props.js";
 import { sendTaskHeartbeat } from "./heartbeat.js";
 import { CallKind, createCall } from "./internal/calls.js";
 import type {
@@ -76,7 +79,8 @@ export interface TaskInvocationOptions {
  */
 export interface TaskOptions
   extends Omit<TaskInvocationOptions, "timeout">,
-    FunctionRuntimeProps {
+    FunctionRuntimeProps,
+    FunctionBundleProps {
   /**
    * How long the workflow will wait for the task to complete or fail.
    *


### PR DESCRIPTION
Support the ability to mark a module as external when bundling a handler.

```ts
command("myCommand", {externalModules: ["typescript"]}, async () => {});
```