### PR TITLE
fix: cli tests randomly fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,8 @@ jobs:
           role-session-name: ${{ github.job	}}
       - name: Run Runtime Tests
         run: pnpm -r --filter tests-runtime run test:runtime
+        env:
+          OUTPUTS_FILE: "${{ steps.deployment-output.outputs.download-path }}/outputs.json"
   test-local:
     needs: [deploy-runtime]
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/build
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::593491530938:role/githubActionStack-githubactionroleA106E4DC-14SHKLVA61IN4
+          aws-region: us-east-1
+          role-duration-seconds: 3600
       - name: Download artifact with variable
         id: deployment-output
         uses: actions/download-artifact@v3
@@ -72,7 +78,6 @@ jobs:
         run: pnpm -r --filter tests-runtime run test:runtime
   test-local:
     needs: [deploy-runtime]
-    concurrency: pr-test-runtime
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -80,6 +85,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/build
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::593491530938:role/githubActionStack-githubactionroleA106E4DC-14SHKLVA61IN4
+          aws-region: us-east-1
+          role-duration-seconds: 3600
       - name: Download artifact with variable
         id: deployment-output
         uses: actions/download-artifact@v3
@@ -113,6 +124,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/build
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::593491530938:role/githubActionStack-githubactionroleA106E4DC-14SHKLVA61IN4
+          aws-region: us-east-1
+          role-duration-seconds: 3600
       - name: Download artifact with variable
         id: deployment-output
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,14 +51,15 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/build
       - name: Download artifact with variable
-        uses: actions/download-artifact@v2
+        id: deployment-output
+        uses: actions/download-artifact@v3
         with:
           name: deployment-output
           path: deployment
       - run: |
-          echo "$(ls)"
-          echo "$(cwd)"
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./deployment/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "${{ steps.deployment-output.outputs.download-path }}"
+          echo $(ls "${{ steps.deployment-output.outputs.download-path }}")
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("${{ steps.deployment-output.outputs.download-path }}/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -82,12 +83,15 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/build
       - name: Download artifact with variable
-        uses: actions/download-artifact@v2
+        id: deployment-output
+        uses: actions/download-artifact@v3
         with:
           name: deployment-output
           path: deployment
       - run: |
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./deployment/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "${{ steps.deployment-output.outputs.download-path }}"
+          echo $(ls "${{ steps.deployment-output.outputs.download-path }}")
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("${{ steps.deployment-output.outputs.download-path }}/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -114,12 +118,15 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/build
       - name: Download artifact with variable
-        uses: actions/download-artifact@v2
+        id: deployment-output
+        uses: actions/download-artifact@v3
         with:
           name: deployment-output
           path: deployment
       - run: |
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./deployment/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "${{ steps.deployment-output.outputs.download-path }}"
+          echo $(ls "${{ steps.deployment-output.outputs.download-path }}")
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("${{ steps.deployment-output.outputs.download-path }}/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,9 @@ jobs:
           role-duration-seconds: 3600
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ env.AWS_SESSION_TOKEN  }}
           role-skip-session-tagging: true
+          role-session-name: ${{ github.job	}}
       - name: Run Runtime Tests
         run: pnpm -r --filter tests-runtime run test:runtime
   test-local:
@@ -106,7 +108,9 @@ jobs:
           role-duration-seconds: 3600
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ env.AWS_SESSION_TOKEN  }}
           role-skip-session-tagging: true
+          role-session-name: ${{ github.job	}}
       - name: Run Local Tests
         run: pnpm -r --filter tests-runtime run test:local-start
   test-cli:
@@ -144,7 +148,9 @@ jobs:
           role-duration-seconds: 3600
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ env.AWS_SESSION_TOKEN  }}
           role-skip-session-tagging: true
+          role-session-name: ${{ github.job	}}
       - name: Run CLI Tests
         run: pnpm -r --filter tests-runtime run test:cli
   test-create:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,7 @@ jobs:
       - uses: ./.github/actions/build
       - name: Run tests
         run: pnpm test
-  test-runtime:
-    needs: [build]
+  deploy-runtime:
     concurrency: pr-test-runtime
     runs-on: ubuntu-latest
     permissions:
@@ -36,6 +35,22 @@ jobs:
         run: pnpm -r --filter tests-runtime run deploy:runtime
         env:
           EVENTUAL_LOCAL: "1"
+      - name: Upload deployment output as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: deployment-output
+          path: ./apps/tests/aws-runtime/cdk.out/outputs.json
+  test-runtime:
+    needs: [deploy-runtime]
+    concurrency: pr-test-runtime
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/build
+      - name: Download artifact with variable
+        uses: actions/download-artifact@v2
+        with:
+          name: deployment-output
       - run: |
           echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./apps/tests/aws-runtime/cdk.out/outputs.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
@@ -50,29 +65,65 @@ jobs:
           role-skip-session-tagging: true
       - name: Run Runtime Tests
         run: pnpm -r --filter tests-runtime run test:runtime
-      - name: Run Local Tests
-        run: pnpm -r --filter tests-runtime run test:local-start
-  test-cli:
-    needs: [test-runtime]
-    runs-on:
-      labels: ubuntu-latest-m
+  test-local:
+    needs: [deploy-runtime]
+    concurrency: pr-test-runtime
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/build
-      - name: Configure AWS Credentials
+      - name: Download artifact with variable
+        uses: actions/download-artifact@v2
+        with:
+          name: deployment-output
+      - run: |
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./apps/tests/aws-runtime/cdk.out/outputs.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+      - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          role-to-assume: arn:aws:iam::593491530938:role/githubActionStack-githubactionroleA106E4DC-14SHKLVA61IN4
+          role-to-assume: ${{ env.TEST_ROLE_ARN }}
           aws-region: us-east-1
           role-duration-seconds: 3600
-      - name: Run CLI Tests
-        run: pnpm -r --filter tests-runtime run test:cli
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ env.AWS_SESSION_TOKEN  }}
+          role-skip-session-tagging: true
+      - name: Run Local Tests
+        run: pnpm -r --filter tests-runtime run test:local-start
+  test-cli:
+    needs: [test-runtime]
+    runs-on:
+      labels: ubuntu-latest-m
     env:
       NODE_OPTIONS: "--max-old-space-size=12096"
       CI: "true"
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/build
+      - name: Download artifact with variable
+        uses: actions/download-artifact@v2
+        with:
+          name: deployment-output
+      - run: |
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./apps/tests/aws-runtime/cdk.out/outputs.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+      - name: Configure Test Role Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ env.TEST_ROLE_ARN }}
+          aws-region: us-east-1
+          role-duration-seconds: 3600
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ env.AWS_SESSION_TOKEN  }}
+          role-skip-session-tagging: true
+      - name: Run CLI Tests
+        run: pnpm -r --filter tests-runtime run test:cli
   test-create:
     needs: [build]
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,6 @@ jobs:
           role-duration-seconds: 3600
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ env.AWS_SESSION_TOKEN  }}
           role-skip-session-tagging: true
       - name: Run Runtime Tests
         run: pnpm -r --filter tests-runtime run test:runtime
@@ -107,7 +106,6 @@ jobs:
           role-duration-seconds: 3600
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ env.AWS_SESSION_TOKEN  }}
           role-skip-session-tagging: true
       - name: Run Local Tests
         run: pnpm -r --filter tests-runtime run test:local-start
@@ -146,7 +144,6 @@ jobs:
           role-duration-seconds: 3600
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ env.AWS_SESSION_TOKEN  }}
           role-skip-session-tagging: true
       - name: Run CLI Tests
         run: pnpm -r --filter tests-runtime run test:cli

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   pull_request: {}
   workflow_call: {}
 jobs:
-  build:
+  unit-tests:
     runs-on: ubuntu-latest
     env:
       CI: "true"
@@ -44,6 +44,9 @@ jobs:
     needs: [deploy-runtime]
     concurrency: pr-test-runtime
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/build
@@ -51,8 +54,9 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: deployment-output
+          path: ./output.json
       - run: |
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./apps/tests/aws-runtime/cdk.out/outputs.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -79,8 +83,9 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: deployment-output
+          path: ./output.json
       - run: |
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./apps/tests/aws-runtime/cdk.out/outputs.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -110,8 +115,9 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: deployment-output
+          path: ./output.json
       - run: |
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./apps/tests/aws-runtime/cdk.out/outputs.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -125,7 +131,6 @@ jobs:
       - name: Run CLI Tests
         run: pnpm -r --filter tests-runtime run test:cli
   test-create:
-    needs: [build]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,9 @@ jobs:
     needs: [test-runtime]
     runs-on:
       labels: ubuntu-latest-m
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Run Runtime Tests
         run: pnpm -r --filter tests-runtime run test:runtime
         env:
-          OUTPUTS_FILE: "${{ steps.deployment-output.outputs.download-path }}/outputs.json"
+          OUTPUTS_FILE: "./deployment/outputs.json"
   test-local:
     needs: [deploy-runtime]
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,9 @@ jobs:
           name: deployment-output
           path: ./output.json
       - run: |
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("/home/runner/work/eventual/eventual/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "$(ls)"
+          echo "$(cwd)"
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -85,7 +87,7 @@ jobs:
           name: deployment-output
           path: ./output.json
       - run: |
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("/home/runner/work/eventual/eventual/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -117,7 +119,7 @@ jobs:
           name: deployment-output
           path: ./output.json
       - run: |
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("/home/runner/work/eventual/eventual/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
       contents: write
       id-token: write
     env:
-      NODE_OPTIONS: "--max-old-space-size=12096"
       CI: "true"
     steps:
       - uses: actions/checkout@v3
@@ -117,10 +116,8 @@ jobs:
         run: pnpm -r --filter tests-runtime run test:local-start
   test-cli:
     needs: [test-runtime]
-    runs-on:
-      labels: ubuntu-latest-m
+    runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: "--max-old-space-size=12096"
       CI: "true"
     permissions:
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           name: deployment-output
           path: ./output.json
       - run: |
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("/home/runner/work/eventual/eventual/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -85,7 +85,7 @@ jobs:
           name: deployment-output
           path: ./output.json
       - run: |
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("/home/runner/work/eventual/eventual/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -117,7 +117,7 @@ jobs:
           name: deployment-output
           path: ./output.json
       - run: |
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("/home/runner/work/eventual/eventual/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,7 @@ jobs:
   test-runtime:
     needs: [build]
     concurrency: pr-test-runtime
-    runs-on:
-      labels: ubuntu-latest-m
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
@@ -49,12 +48,28 @@ jobs:
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ env.AWS_SESSION_TOKEN  }}
           role-skip-session-tagging: true
-      - name: Run Local Tests
-        run: pnpm -r --filter tests-runtime run test:local-start
       - name: Run Runtime Tests
         run: pnpm -r --filter tests-runtime run test:runtime
+      - name: Run Local Tests
+        run: pnpm -r --filter tests-runtime run test:local-start
+  test-cli:
+    needs: [test-runtime]
+    runs-on:
+      labels: ubuntu-latest-m
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/build
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::593491530938:role/githubActionStack-githubactionroleA106E4DC-14SHKLVA61IN4
+          aws-region: us-east-1
+          role-duration-seconds: 3600
       - name: Run CLI Tests
         run: pnpm -r --filter tests-runtime run test:cli
+    env:
+      NODE_OPTIONS: "--max-old-space-size=12096"
+      CI: "true"
   test-create:
     needs: [build]
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Run Runtime Tests
         run: pnpm -r --filter tests-runtime run test:runtime
         env:
-          OUTPUTS_FILE: "./deployment/outputs.json"
+          OUTPUTS_FILE: "${{ steps.deployment-output.outputs.download-path }}/outputs.json"
   test-local:
     needs: [deploy-runtime]
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           EVENTUAL_LOCAL: "1"
       - name: Upload deployment output as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: deployment-output
           path: ./apps/tests/aws-runtime/cdk.out/outputs.json
@@ -57,9 +57,7 @@ jobs:
           name: deployment-output
           path: deployment
       - run: |
-          echo "${{ steps.deployment-output.outputs.download-path }}"
-          echo $(ls "${{ steps.deployment-output.outputs.download-path }}")
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("${{ steps.deployment-output.outputs.download-path }}/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("${{ steps.deployment-output.outputs.download-path }}/outputs.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -89,9 +87,7 @@ jobs:
           name: deployment-output
           path: deployment
       - run: |
-          echo "${{ steps.deployment-output.outputs.download-path }}"
-          echo $(ls "${{ steps.deployment-output.outputs.download-path }}")
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("${{ steps.deployment-output.outputs.download-path }}/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("${{ steps.deployment-output.outputs.download-path }}/outputs.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -124,9 +120,7 @@ jobs:
           name: deployment-output
           path: deployment
       - run: |
-          echo "${{ steps.deployment-output.outputs.download-path }}"
-          echo $(ls "${{ steps.deployment-output.outputs.download-path }}")
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("${{ steps.deployment-output.outputs.download-path }}/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("${{ steps.deployment-output.outputs.download-path }}/outputs.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,13 @@ jobs:
   test-runtime:
     needs: [build]
     concurrency: pr-test-runtime
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ubuntu-latest-m
     permissions:
       contents: write
       id-token: write
     env:
+      NODE_OPTIONS: "--max-old-space-size=12096"
       CI: "true"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,11 +54,11 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: deployment-output
-          path: ./output.json
+          path: deployment
       - run: |
           echo "$(ls)"
           echo "$(cwd)"
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./deployment/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -85,9 +85,9 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: deployment-output
-          path: ./output.json
+          path: deployment
       - run: |
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./deployment/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -117,9 +117,9 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: deployment-output
-          path: ./output.json
+          path: deployment
       - run: |
-          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
+          echo "TEST_ROLE_ARN=$(node -p 'JSON.parse(require("fs").readFileSync("./deployment/output.json"))["eventual-tests"].roleArn')" >> $GITHUB_ENV
       - name: Configure Test Role Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:

--- a/apps/tests/aws-runtime-cdk/src/chaos-extension.ts
+++ b/apps/tests/aws-runtime-cdk/src/chaos-extension.ts
@@ -84,7 +84,7 @@ export class ChaosExtension extends Construct {
   /**
    * Grant the ability to read and write the SSM parameter used by the chaos extension.
    *
-   * This is required to use the {@link SSMChaosClient}.
+   * This is required to use the {@link ChaosClient}.
    */
   public grantReadWrite(grantable: IGrantable) {
     this.ssm.grantRead(grantable);

--- a/apps/tests/aws-runtime/package.json
+++ b/apps/tests/aws-runtime/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0",
   "main": "lib/test-service.js",
   "scripts": {
-    "test:runtime": "NODE_OPTIONS=--experimental-vm-modules OUTPUTS_FILE=cdk.out/outputs.json jest --passWithNoTests",
+    "test:runtime": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
     "test:local": "NODE_OPTIONS=--experimental-vm-modules TEST_LOCAL=1 jest --passWithNoTests",
     "test:cli": "./scripts/test-cli",
     "test:create": "./scripts/test-create",

--- a/apps/tests/aws-runtime/scripts/test-cli
+++ b/apps/tests/aws-runtime/scripts/test-cli
@@ -16,6 +16,8 @@ npx eventual list executions
 
 npx eventual list executions --workflow sleepy --json > .eventual/out.json
 
+mkdir -p .eventual
+
 execution_id=$(node -p 'JSON.parse(require("fs").readFileSync(".eventual/out.json").toString("utf8")).executions[0].id')
 
 npx eventual get history -e ${execution_id}

--- a/apps/tests/aws-runtime/scripts/test-cli
+++ b/apps/tests/aws-runtime/scripts/test-cli
@@ -14,9 +14,9 @@ npx eventual start workflow sleepy -f
 
 npx eventual list executions
 
-npx eventual list executions --workflow sleepy --json > .eventual/out.json
-
 mkdir -p .eventual
+
+npx eventual list executions --workflow sleepy --json > .eventual/out.json
 
 execution_id=$(node -p 'JSON.parse(require("fs").readFileSync(".eventual/out.json").toString("utf8")).executions[0].id')
 

--- a/apps/tests/aws-runtime/test/env.ts
+++ b/apps/tests/aws-runtime/test/env.ts
@@ -9,8 +9,6 @@ const outputs =
     ? JSON.parse(fs.readFileSync(path.resolve(outputsFile)).toString("utf-8"))
     : undefined;
 
-console.log(path.resolve(outputsFile), outputsFile, outputs);
-
 export const awsRegion = () => process.env.AWS_REGION ?? "us-east-1";
 export const serviceUrl = () =>
   outputs?.["eventual-tests"]?.serviceUrl ?? "http://localhost:3111";

--- a/apps/tests/aws-runtime/test/env.ts
+++ b/apps/tests/aws-runtime/test/env.ts
@@ -9,6 +9,8 @@ const outputs =
     ? JSON.parse(fs.readFileSync(path.resolve(outputsFile)).toString("utf-8"))
     : undefined;
 
+console.log(path.resolve(outputsFile), outputsFile, outputs);
+
 export const awsRegion = () => process.env.AWS_REGION ?? "us-east-1";
 export const serviceUrl = () =>
   outputs?.["eventual-tests"]?.serviceUrl ?? "http://localhost:3111";

--- a/packages/@eventual/aws-cdk/src/command-service.ts
+++ b/packages/@eventual/aws-cdk/src/command-service.ts
@@ -185,6 +185,7 @@ export class CommandService<Service = any> {
           this.props.build.system.eventualService.systemCommandHandler,
         functionNameSuffix: "system-command",
         serviceName: this.props.serviceName,
+        // the logs command is the outlier here. Was often timing out at 3 seconds.
         defaults: { timeout: Duration.seconds(30) },
       }
     );

--- a/packages/@eventual/aws-cdk/src/command-service.ts
+++ b/packages/@eventual/aws-cdk/src/command-service.ts
@@ -185,6 +185,7 @@ export class CommandService<Service = any> {
           this.props.build.system.eventualService.systemCommandHandler,
         functionNameSuffix: "system-command",
         serviceName: this.props.serviceName,
+        defaults: { timeout: Duration.seconds(30) },
       }
     );
 

--- a/packages/@eventual/cli/src/commands/logs.ts
+++ b/packages/@eventual/cli/src/commands/logs.ts
@@ -81,8 +81,13 @@ export const logs = (yargs: Argv) =>
         };
 
         do {
-          const fetchResult = await fetchLogs(logFilter, logCursor);
-          logCursor = updateLogCursor(logCursor, fetchResult, follow);
+          try {
+            const fetchResult = await fetchLogs(logFilter, logCursor);
+            logCursor = updateLogCursor(logCursor, fetchResult, follow);
+          } catch (err) {
+            console.error(err);
+            throw err;
+          }
 
           if (follow) {
             spinner.start("Watching logs");

--- a/packages/@eventual/cli/src/commands/logs.ts
+++ b/packages/@eventual/cli/src/commands/logs.ts
@@ -110,16 +110,15 @@ export const logs = (yargs: Argv) =>
 
           const functionEvents = output.events ?? [];
 
-          // Print out the interleaved logs
           if (functionEvents.length) {
             spinner.stop();
             functionEvents.forEach((ev) => {
-              console.log(
+              process.stdout.write(
                 `${
                   logFilter.executionId ? "" : `[${chalk.blue(ev.source)}] `
                 }${chalk.red(new Date(ev.time!).toLocaleString())} ${
                   ev.message
-                }`
+                }\n`
               );
             });
           }

--- a/packages/@eventual/cli/src/commands/logs.ts
+++ b/packages/@eventual/cli/src/commands/logs.ts
@@ -105,6 +105,7 @@ export const logs = (yargs: Argv) =>
               ? new Date(logCursor.startTime).toISOString()
               : undefined,
             workflowName: logFilter.workflowName,
+            maxResults: 1000,
           });
 
           const functionEvents = output.events ?? [];


### PR DESCRIPTION
The logs lambda was timing out and then silently failing the logs command. Added error reporting to the logs command along with an increased timeout on the system command lambda.

Also refactored the build/test github action to be smaller units in with more in parallel.