### PR TITLE
fix: do not encode string as JSON when writing to S3 local

### DIFF
--- a/packages/@eventual/core-runtime/src/local/stores/bucket-store.ts
+++ b/packages/@eventual/core-runtime/src/local/stores/bucket-store.ts
@@ -54,14 +54,7 @@ export class LocalBucketStore implements BucketStore, LocalSerializable {
           const metaKey = `${bucketName}/${prefix}-${randomizer}${META_SUFFIX}`;
           const { body, ...meta } = value;
           return [
-            [
-              key,
-              Buffer.from(
-                typeof value.body === "string"
-                  ? JSON.stringify(value.body)
-                  : value.body
-              ),
-            ],
+            [key, Buffer.from(value.body)],
             [metaKey, Buffer.from(JSON.stringify(meta))],
           ];
         })


### PR DESCRIPTION
We should not modify the string data written to S3 when persisting local.